### PR TITLE
Refactor the kThermoRead a bit

### DIFF
--- a/gaggiuino.ino
+++ b/gaggiuino.ino
@@ -310,10 +310,8 @@ void kThermoRead() { // Reading the thermocouple temperature
     kProbeReadValue = thermocouple.readCelsius();  // Making sure we're getting a value
     while (kProbeReadValue <= 0 || kProbeReadValue == NAN || kProbeReadValue > 170.0) {
       PORTB &= ~_BV(PB0);  // relayPin -> LOW
-      if ((millis() - thermoTimer) > GET_KTYPE_READ_EVERY){
-        kProbeReadValue = thermocouple.readCelsius();  // Making sure we're getting a value
-        thermoTimer = millis();
-      }
+      delay(GET_KTYPE_READ_EVERY);
+      kProbeReadValue = thermocouple.readCelsius();  // Making sure we're getting a value
     }
     thermoTimer = millis();
   }


### PR DESCRIPTION
This is awesome project. While I'm waiting for my hardware delivered, I'm reading through the code and figuring out how I could adapt it to the RTD Pt100 which I purchased. 

The  original code looks like doing 
1 read (fail) -> 1 read (fail) - empty loop for GET_KTYPE_READ_EVERY milliseconds -> read -> empty loop -> read. Which seems not matching the minimal interval between two reads. It is two immediately reading and then follow the interval. Is that on purpose?