### PR TITLE
+ prevent HX711 critical section from interfering with pumping

### DIFF
--- a/src/gaggiuino.ino
+++ b/src/gaggiuino.ino
@@ -155,6 +155,7 @@ unsigned int ppHold;
 unsigned int ppLength;
 unsigned int selectedOperationalMode;
 unsigned int regionHz;
+unsigned int pumpValue;
 
 // EEPROM  stuff
 const unsigned int  EEP_SETPOINT = 1;
@@ -272,6 +273,8 @@ void calculateWeight() {
   // Weight output
   if (millis() > scalesTimer) {
     if (scalesPresent && weighingStartRequested) {
+      // Stop pump to prevent HX711 critical section from breaking timing
+      pump.set(0);
       #if defined(SINGLE_HX711_CLOCK)
         float values[2];
         LoadCells.get_units(values);
@@ -279,6 +282,8 @@ void calculateWeight() {
       #else
         currentWeight = LoadCell_1.get_units() + LoadCell_2.get_units();
       #endif
+      // Resume pumping
+      pump.set(pumpValue);
     }
     scalesTimer = millis() + GET_SCALES_READ_EVERY;
   }
@@ -338,10 +343,9 @@ float getPressure() {  //returns sensor pressure data
 
 
 #if defined(ARDUINO_ARCH_AVR)
-void setPressure(int targetValue) { 
-  unsigned int pumpValue; 
+void setPressure(int targetValue) {
   if (targetValue == 0 || livePressure > targetValue) {
-    pump.set(0);
+    pumpValue = 0;
   } else if(livePressure < targetValue-1.f) {
     if (!preinfusionFinished && (selectedOperationalMode == 1 || selectedOperationalMode == 4)) {
       pumpValue = (PUMP_RANGE - livePressure * targetValue)/4;
@@ -350,20 +354,19 @@ void setPressure(int targetValue) {
       pumpValue = PUMP_RANGE - livePressure * targetValue;
       if (livePressure > targetValue) pumpValue = 0;
     }
-    pump.set(pumpValue);
   } else if(livePressure >= targetValue-1.f && livePressure < targetValue) {
     if (selectedOperationalMode == 1 || selectedOperationalMode == 4) {
       pumpValue = (PUMP_RANGE - livePressure * targetValue)/4;
       if (livePressure > targetValue) pumpValue = 0;
     }
-    pump.set(pumpValue);
   }
+  pump.set(pumpValue);
 }
 #elif defined(ARDUINO_ARCH_STM32)
 void setPressure(int targetValue) { 
   unsigned int pumpValue; 
   if (targetValue == 0 || livePressure > targetValue) {
-    pump.set(0);
+    pumpValue = 0;
   } else if(livePressure < targetValue-1.f) {
     if (!preinfusionFinished && (selectedOperationalMode == 1 || selectedOperationalMode == 4)) {
       pumpValue = (PUMP_RANGE - livePressure * targetValue)/2;
@@ -372,14 +375,13 @@ void setPressure(int targetValue) {
       pumpValue = PUMP_RANGE - livePressure * targetValue;
       if (livePressure > targetValue) pumpValue = 0;
     }
-    pump.set(pumpValue);
   } else if(livePressure >= targetValue-1.f && livePressure < targetValue) {
     if (selectedOperationalMode == 1 || selectedOperationalMode == 4) {
       pumpValue = (PUMP_RANGE - livePressure * targetValue)/2;
       if (livePressure > targetValue) pumpValue = 0;
     }
-    pump.set(pumpValue);
   }
+  pump.set(pumpValue);
 }
 #endif
 


### PR DESCRIPTION
The HX711 talks a really awkward protocol that doesn't lend itself to hardware acceleration. The tight timing required means the HX711 library switches off interrupts for the duration of any communications, switching them on again afterwards. There is the possibility this will mean zero crossing interrupts are missed or delivered late. This means there's the risk that it might prevent the PSM library from switching the power properly for a cycle, causing pressure spikes. It will also make modelling flow in future more difficult. 