### PR TITLE
Add static code analyzers stm32

### DIFF
--- a/.github/workflows/compile-sketch.yml
+++ b/.github/workflows/compile-sketch.yml
@@ -48,3 +48,7 @@ jobs:
       - name: Build Gaggiuino
         run: |
           ~/.platformio/penv/bin/platformio run
+
+      - name: Run code analyzers
+        run: |
+          ~/.platformio/penv/bin/platformio check -e nano --fail-on-defect high

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,11 +22,11 @@ check_skip_packages = yes
 
 [extra]
 lib_deps_external =
-	seithan/Easy Nextion Library@^1.0.6
 	adafruit/MAX6675 library@^1.1.0
 	khoih-prog/TimerInterrupt_Generic@^1.8.0
 	https://github.com/banoz/PSM.Library.git
 	https://github.com/banoz/HX711.git
+	https://github.com/Seithan/EasyNextionLibrary.git#4bd06b2a428da3cfd17f54dfd654ff2da6867ddb
 	; https://github.com/lis0r/HX711.git#feature/twinboard
 
 [env:nano]

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,11 @@ default_envs = blackpill
 
 [env]
 framework = arduino
+check_tool = cppcheck, clangtidy
+check_flags =
+	cppcheck: --enable=all --inline-suppr
+	clangtidy: --checks=bugprone-*,cert-*,cppcoreguidelines-*,performance-*,-cppcoreguidelines-avoid-non-const-global-variables,-cppcoreguidelines-macro-usage
+check_skip_packages = yes
 
 [extra]
 lib_deps_external =

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,7 @@ default_envs = blackpill
 [env]
 framework = arduino
 lib_compat_mode = strict
+build_flags = "-Wall"
 check_tool = cppcheck, clangtidy
 check_flags =
 	cppcheck: --enable=all --inline-suppr

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,6 +14,7 @@ default_envs = blackpill
 
 [env]
 framework = arduino
+lib_compat_mode = strict
 check_tool = cppcheck, clangtidy
 check_flags =
 	cppcheck: --enable=all --inline-suppr
@@ -32,14 +33,12 @@ lib_deps_external =
 [env:nano]
 platform = atmelavr
 board = nanoatmega328
-lib_compat_mode = strict
 lib_deps =
 	${extra.lib_deps_external}
 
 [env:nanonew]
 platform = atmelavr
 board = nanoatmega328new
-lib_compat_mode = strict
 lib_deps =
 	${extra.lib_deps_external}
 

--- a/src/gaggiuino.cpp
+++ b/src/gaggiuino.cpp
@@ -660,7 +660,7 @@ void lcdRefresh() {
 void trigger1() {
   #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_STM32)
     int valueToSave;
-    int allValuesUpdated;
+    int allValuesUpdated = 0;
 
     switch (myNex.currentPageId){
       case 1:
@@ -719,7 +719,6 @@ void trigger1() {
           allValuesUpdated++;
         }
         if (allValuesUpdated == 9) {
-          allValuesUpdated=0;
           myNex.writeStr("popupMSG.t0.txt","UPDATE SUCCESSFUL!");
         }else myNex.writeStr("popupMSG.t0.txt","ERROR!");
         myNex.writeStr("page popupMSG");
@@ -742,7 +741,6 @@ void trigger1() {
           allValuesUpdated++;
         }
         if (allValuesUpdated == 3) {
-          allValuesUpdated=0;
           myNex.writeStr("popupMSG.t0.txt","UPDATE SUCCESSFUL!");
         }else myNex.writeStr("popupMSG.t0.txt","ERROR!");
         myNex.writeStr("page popupMSG");
@@ -781,7 +779,6 @@ void trigger1() {
           allValuesUpdated++;
         }
         if (allValuesUpdated == 5) {
-          allValuesUpdated=0;
           myNex.writeStr("popupMSG.t0.txt","UPDATE SUCCESSFUL!");
         }else myNex.writeStr("popupMSG.t0.txt","ERROR!");
         myNex.writeStr("page popupMSG");
@@ -799,7 +796,6 @@ void trigger1() {
           allValuesUpdated++;
         }
         if (allValuesUpdated == 2) {
-          allValuesUpdated=0;
           myNex.writeStr("popupMSG.t0.txt","UPDATE SUCCESSFUL!");
         }else myNex.writeStr("popupMSG.t0.txt","ERROR!");
         myNex.writeStr("page popupMSG");

--- a/src/gaggiuino.cpp
+++ b/src/gaggiuino.cpp
@@ -219,7 +219,7 @@ float pressureTargetComparator;
 #define  EEP_SCALES_F1           215
 #define  EEP_SCALES_F2           220
 
-
+// cppcheck-suppress unusedFunction
 void setup() {
   // USART_CH1.begin(115200); //debug channel
   USART_CH.begin(115200); // LCD comms channel
@@ -265,6 +265,7 @@ void setup() {
 
 
 //Main loop where all the logic is continuously run
+// cppcheck-suppress unusedFunction
 void loop() {
   pageValuesRefresh();
   myNex.NextionListen();
@@ -655,6 +656,7 @@ void lcdRefresh() {
 //###################################____SAVE_BUTTON____#######################################
 //#############################################################################################
 // Save the desired temp values to EEPROM
+// cppcheck-suppress unusedFunction
 void trigger1() {
   #if defined(ARDUINO_ARCH_AVR) || defined(ARDUINO_ARCH_STM32)
     int valueToSave;
@@ -812,12 +814,14 @@ void trigger1() {
 //###################################_____SCALES_TARE____######################################
 //#############################################################################################
 
+// cppcheck-suppress unusedFunction
 void trigger2() {
   tareDone = false;
   previousBrewState = false;
   scalesTare();
 }
 
+// cppcheck-suppress unusedFunction
 void trigger3() {
   homeScreenScalesEnabled = myNex.readNumber("scalesEnabled");
 }

--- a/src/gaggiuino.cpp
+++ b/src/gaggiuino.cpp
@@ -385,7 +385,7 @@ void setPressure(int targetValue) {
   #elif defined(ARDUINO_ARCH_STM32)
     #define FLOW_DIV 4
   #endif
-  int pumpValue;
+  int pumpValue = 0;
   static bool initialRampUp;
 
   if (targetValue == 0 || livePressure > targetValue) {
@@ -945,7 +945,7 @@ void deScale(bool c) {
 // Pressure profiling function, uses dimmer to dim the pump
 // Linear dimming as time passes, goes from pressure start to end incrementally or decrementally
 void autoPressureProfile() {
-  float newBarValue;
+  float newBarValue = 0;
   // static long ppTimer = millis();
 
   if (brewActive) { //runs this only when brew button activated and pressure profile selected

--- a/src/gaggiuino.cpp
+++ b/src/gaggiuino.cpp
@@ -392,7 +392,7 @@ void setPressure(int targetValue) {
   if (targetValue == 0 || livePressure > targetValue) {
     pumpValue = 0;
     initialRampUp = true;
-  } else if (livePressure < targetValue-0.3f & !initialRampUp) {
+  } else if (livePressure < targetValue-0.3f && !initialRampUp) {
     if (!preinfusionFinished && (selectedOperationalMode == 1 || selectedOperationalMode == 4)) {
       pumpValue = (PUMP_RANGE - livePressure * targetValue) / FLOW_DIV;
       if (livePressure > targetValue) pumpValue = 0;

--- a/src/gaggiuino.cpp
+++ b/src/gaggiuino.cpp
@@ -481,7 +481,7 @@ void modeSelect() {
       // USART_CH1.println("MODE SELECT 4");
       if (!steamState() ) {
         if(!preinfusionFinished) preInfusion();
-        else if(preinfusionFinished) autoPressureProfile();
+        else autoPressureProfile();
       } else steamCtrl();
       break;
     case 5:
@@ -613,7 +613,7 @@ void steamCtrl() {
       if ((kProbeReadValue > setPoint-10.00) && (kProbeReadValue <=155)) setBoiler(HIGH);  // relayPin -> HIGH
       else setBoiler(LOW);  // relayPin -> LOW
     }else if(livePressure >=9.1) setBoiler(LOW);  // relayPin -> LOW
-  }else if (brewActive) { //added to cater for hot water from steam wand functionality
+  }else { //added to cater for hot water from steam wand functionality
     if ((kProbeReadValue > setPoint-10.00) && (kProbeReadValue <=105)) {
       setBoiler(HIGH);  // relayPin -> HIGH
       setPressure(9);
@@ -621,7 +621,7 @@ void steamCtrl() {
       setBoiler(LOW);  // relayPin -> LOW
       setPressure(9);
     }
-  }else setBoiler(LOW);  // relayPin -> LOW
+  }
 }
 
 //#############################################################################################

--- a/src/gaggiuino.cpp
+++ b/src/gaggiuino.cpp
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #define SINGLE_HX711_CLOCK
 #if defined(ARDUINO_ARCH_AVR)
   #include <EEPROM.h>
@@ -13,7 +14,6 @@
   #include <HX711.h>
 #endif
 #include <PSM.h>
-
 
 
 #if defined(ARDUINO_ARCH_AVR)
@@ -104,6 +104,29 @@ HX711 LoadCell_1; //HX711 1
 HX711 LoadCell_2; //HX711 2
 #endif
 
+void pinInit();
+void ads1115Init();
+void setBoiler(int);
+void eepromInit();
+void initPressure(int);
+void scalesInit();
+void pageValuesRefresh();
+void sensorsRead();
+void brewDetect();
+void modeSelect();
+void lcdRefresh();
+float getPressure();
+void scalesTare();
+void calculateFlow();
+bool steamState();
+void justDoCoffee();
+void steamCtrl();
+void preInfusion();
+void autoPressureProfile();
+void manualPressureProfile();
+void deScale(bool);
+float mapRange(float, float, float, float, float, int);
+void valuesLoadFromEEPROM();
 
 // Some vars are better global
 //Timers


### PR DESCRIPTION
Summary of what this PR do:
- Enables cppcheck and clang-tidy and adds them to the github workflow (only critical issues break the build)
- Clang-tidy gives more false positives it seems but it's still good to have it
- Clang-tidy can be fine tuned in terms of what plugin it uses, I chose a very basic set
- Clang-tidy doesn't work well with ino files, so I renamed the main sketch to `gaggiuino.cpp`, this makes using Arduino IDE difficult, but I hope that everyone uses something better already. Moreover once the code begin to get bigger and more structured we need to introduce cpp/h files anyway (which would make using Arduino IDE impossible probably).
- Fixes most of the issues reported by cppcheck, the most critical one is this 1d4b2e549493f3b3f6a3be36e0e5cc6b8c1e3dcf
- Adds `-Wall` build flag and `strict` `lib_compat_mode` to all platforms
- Bumps Nextion library to the revision with boolean->bool fixes