### PR TITLE
Move scales to peripherals

### DIFF
--- a/src/peripherals/scales.cpp
+++ b/src/peripherals/scales.cpp
@@ -1,0 +1,73 @@
+#include "scales.h"
+#include "pindef.h"
+
+#if defined(SINGLE_HX711_CLOCK)
+#include <HX711_2.h>
+HX711_2 LoadCells;
+#else
+#include <HX711.h>
+HX711 LoadCell_1; //HX711 1
+HX711 LoadCell_2; //HX711 2
+#endif
+
+bool scalesPresent;
+
+void scalesInit(float scalesF1, float scalesF2) {
+
+  #if defined(SINGLE_HX711_CLOCK)
+    LoadCells.begin(HX711_dout_1, HX711_dout_2, HX711_sck_1);
+    LoadCells.set_scale(scalesF1, scalesF2);
+    LoadCells.power_up();
+
+    delay(500);
+
+    if (LoadCells.is_ready()) {
+      LoadCells.tare(5);
+      scalesPresent = true;
+    }
+  #else
+    LoadCell_1.begin(HX711_dout_1, HX711_sck_1);
+    LoadCell_2.begin(HX711_dout_2, HX711_sck_2);
+    LoadCell_1.set_scale(scalesF1); // calibrated val1
+    LoadCell_2.set_scale(scalesF2); // calibrated val2
+
+    delay(500);
+
+    if (LoadCell_1.is_ready() && LoadCell_2.is_ready()) {
+      scalesPresent = true;
+      LoadCell_1.tare();
+      LoadCell_2.tare();
+    }
+  #endif
+}
+
+void scalesTare(void) {
+  if(scalesPresent) {
+    #if defined(SINGLE_HX711_CLOCK)
+      if (LoadCells.is_ready()) LoadCells.tare(5);
+    #else
+      if (LoadCell_1.wait_ready_timeout(300) && LoadCell_2.wait_ready_timeout(300)) {
+        LoadCell_1.tare(2);
+        LoadCell_2.tare(2);
+      }
+    #endif
+  }
+}
+
+float scalesGetWeight(void) {
+  float currentWeight = 0;
+
+  if(scalesPresent) {
+    #if defined(SINGLE_HX711_CLOCK)
+      if (LoadCells.is_ready()) {
+        float values[2];
+        LoadCells.get_units(values);
+        currentWeight = values[0] + values[1];
+      }
+    #else
+      currentWeight = LoadCell_1.get_units() + LoadCell_2.get_units();
+    #endif
+  }
+
+  return currentWeight;
+}

--- a/src/peripherals/scales.h
+++ b/src/peripherals/scales.h
@@ -1,0 +1,8 @@
+#ifndef SCALES_H
+#define SCALES_H
+
+void scalesInit(float scalesF1, float scalesF2);
+void scalesTare(void);
+float scalesGetWeight(void);
+
+#endif

--- a/test/HX711.cpp
+++ b/test/HX711.cpp
@@ -1,0 +1,62 @@
+#include "HX711.h"
+
+
+
+HX711::HX711() {
+
+}
+
+HX711::~HX711() {
+
+}
+
+
+void HX711::begin(byte dout, byte pd_sck, byte gain) {
+
+}
+
+bool HX711::is_ready() {
+  return true;
+}
+
+void HX711::wait_ready(unsigned long delay_ms) {
+
+}
+
+bool HX711::wait_ready_retry(int retries, unsigned long delay_ms) {
+  return true;
+}
+
+bool HX711::wait_ready_timeout(unsigned long timeout, unsigned long delay_ms) {
+  return true;
+}
+
+void HX711::set_gain(byte gain) {
+
+}
+
+
+long HX711::read(unsigned long timeout) {
+  return 0;
+}
+
+long HX711::read_average(byte times) {
+  return 0;
+}
+
+long HX711::get_value(byte times) {
+  return 0;
+}
+
+float HX711::get_units(byte times) {
+  return 0;
+}
+
+void HX711::tare(byte times) {
+
+}
+
+void HX711::set_scale(float scale) {
+
+}
+

--- a/test/HX711.h
+++ b/test/HX711.h
@@ -1,0 +1,50 @@
+#include <Arduino.h>
+
+class HX711
+{
+  public:
+
+    HX711();
+    virtual ~HX711();
+    // Initialize library with data output pin, clock input pin and gain factor.
+    // Channel selection is made by passing the appropriate gain:
+    // - With a gain factor of 64 or 128, channel A is selected
+    // - With a gain factor of 32, channel B is selected
+    // The library default is "128" (Channel A).
+    void begin(byte dout, byte pd_sck, byte gain = 128);
+    // Check if HX711 is ready
+    // from the datasheet: When output data is not ready for retrieval, digital output pin DOUT is high. Serial clock
+    // input PD_SCK should be low. When DOUT goes to low, it indicates data is ready for retrieval.
+    bool is_ready();
+    // Wait for the HX711 to become ready
+    void wait_ready(unsigned long delay_ms = 0);
+    bool wait_ready_retry(int retries = 3, unsigned long delay_ms = 0);
+    bool wait_ready_timeout(unsigned long timeout = 1000, unsigned long delay_ms = 0);
+    // set the gain factor; takes effect only after a call to read()
+    // channel A can be set for a 128 or 64 gain; channel B has a fixed 32 gain
+    // depending on the parameter, the channel is also set to either A or B
+    void set_gain(byte gain = 128);
+    // waits for the chip to be ready and returns a reading
+    long read(unsigned long timeout = 1000);
+    // returns an average reading; times = how many times to read
+    long read_average(byte times = 10);
+    // returns (read_average() - OFFSET), that is the current value without the tare weight; times = how many readings to do
+    long get_value(byte times = 1);
+    // returns get_value() divided by SCALE, that is the raw value divided by a value obtained via calibration
+    // times = how many readings to do
+    float get_units(byte times = 1);
+    // set the OFFSET value for tare weight; times = how many times to read the tare value
+    void tare(byte times = 10);
+    // set the SCALE value; this value is used to convert the raw data to "human readable" data (measure units)
+    void set_scale(float scale = 1.f);
+    // get the current SCALE
+    float get_scale();
+    // set OFFSET, the value that's subtracted from the actual reading (tare weight)
+    void set_offset(long offset = 0);
+    // get the current OFFSET
+    long get_offset();
+    // puts the chip into power down mode
+    void power_down();
+    // wakes up the chip after power down mode
+    void power_up();
+};

--- a/test/mock.h
+++ b/test/mock.h
@@ -7,6 +7,9 @@
 #define PA4   1
 #define PC15  1
 #define PA0   1
+#define PB0   1
+#define PA2   1
+#define PB1   1
 
 #define va_start(args, msg)
 #define va_end(args)


### PR DESCRIPTION
**UNTESTED** (since I don't have scales)

* `previousBrewState` var removed cause it was just mirroring the `tareDone` vr
* Scale factors are now sent as arguments to the `scaleInit` function and uses values from EEPROM (4000 both) because that's what scales effectively used in the past too.
* `calculateWeight` and `calculateFlow` were merged to `calculateWeightAndFlow`, there is difference that flow is computed only if the scales are present.
* Scales can be tared anytime via the LCD button since `trigger2` function doesn't raise the `tareDone` flag anymore.