### PR TITLE
Add auto-version

### DIFF
--- a/auto-version.py
+++ b/auto-version.py
@@ -1,0 +1,27 @@
+import subprocess
+
+Import("env")
+
+def get_firmware_version_build_flag():
+  ret = subprocess.run(["git", "describe", "--always"], stdout=subprocess.PIPE, text=True)
+
+  if ret.returncode == 0:
+    build_version = ret.stdout.strip()
+  else:
+    build_version = ""
+    try:
+      with open('VERSION') as f:
+        build_version = f.readline().strip()
+    except:
+        pass
+
+    if build_version == "":
+      build_version = "nogit"
+
+  build_flag = "-D AUTO_VERSION=\\\"" + build_version + "\\\""
+  print ("\nFIRMWARE VERSION: " + build_version)
+  return (build_flag)
+
+env.Append(
+  BUILD_FLAGS=[get_firmware_version_build_flag()]
+)

--- a/platformio.ini
+++ b/platformio.ini
@@ -15,6 +15,7 @@ default_envs = blackpill
 framework = arduino
 platform = ststm32
 board = blackpill_f411ce
+extra_scripts = pre:auto-version.py
 upload_protocol = stlink
 debug_tool = stlink
 monitor_speed = 115200

--- a/src/gaggiuino.ino
+++ b/src/gaggiuino.ino
@@ -97,7 +97,7 @@ float pressureTargetComparator;
 
 void setup() {
   LOG_INIT();
-  LOG_INFO("Gaggiuino booting");
+  LOG_INFO("Gaggiuino (fw: %s) booting", AUTO_VERSION);
 
   // Various pins operation mode handling
   pinInit();


### PR DESCRIPTION
- This defines an `AUTO_VERSION` which contains either:
  - git sha of a commit the firmware binary was built from
  - content of `VERSION` file (this is supposed to be used mainly for github releases)
  - `nogit` if none of the previous data are available
  
- Adding the macro here https://github.com/Zer0-bit/gaggiuino/compare/dev...MartinHruza:gaggiuino:auto-version?expand=1#diff-d6a863d24c8ed77faa8d808068856fe68edbe35756d51aa7aaa80d781803468fR100 is a bit pointless since USB-CDC handshake is too slow 
- It would be great to display this somewhere on the LCD so both users and developers would know what version they are actually running 