### PR TITLE
Improve code readability and decoupling for brewDetect and weightingCode

### DIFF
--- a/src/gaggiuino.ino
+++ b/src/gaggiuino.ino
@@ -47,9 +47,6 @@ float shotWeight;
 float currentWeight;
 float previousWeight;
 float flowVal;
-
-//int tarcalculateWeight;
-bool weighingStartRequested;
 bool tareDone = false;
 
 // brew detection vars

--- a/src/gaggiuino.ino
+++ b/src/gaggiuino.ino
@@ -517,7 +517,7 @@ void trigger1(void) {
 
 void trigger2(void) {
   LOG_VERBOSE("Tare scales");
-  scalesTare();
+  if (scalesIsPresent()) scalesTare();
 }
 
 void trigger3(void) {

--- a/src/gaggiuino.ino
+++ b/src/gaggiuino.ino
@@ -23,7 +23,7 @@
 #define DESCALE_PHASE2_EVERY    5000 // short pause for pulse effficience activation
 #define DESCALE_PHASE3_EVERY    120000 // long pause for scale softening
 #define DELTA_RANGE             0.25f // % to apply as delta
-#define BEAUTIFY_GRAPH          true
+#define BEAUTIFY_GRAPH
 
 // EasyNextion object init
 EasyNex myNex(USART_LCD);
@@ -419,11 +419,11 @@ static void lcdRefresh(void) {
 
   if (millis() > pageRefreshTimer) {
     /*LCD pressure output, as a measure to beautify the graphs locking the live pressure read for the LCD alone*/
-    if (BEAUTIFY_GRAPH) {
+    #ifdef BEAUTIFY_GRAPH
       myNex.writeNum("pressure.val", (livePressure > 0.f) ? (livePressure <= pressureTargetComparator + 0.5f) ? livePressure*10.f : pressureTargetComparator*10.f : 0.f);
-    } else {
+    #else
       myNex.writeNum("pressure.val", (livePressure > 0.f) ? livePressure*10.f : 0.f);
-    }
+    #endif
 
     /*LCD temp output*/
     myNex.writeNum("currentTemp",int(kProbeReadValue - runningCfg.offsetTemp));

--- a/src/peripherals/scales.cpp
+++ b/src/peripherals/scales.cpp
@@ -71,3 +71,7 @@ float scalesGetWeight(void) {
 
   return currentWeight;
 }
+
+bool scalesIsPresent(void) {
+  return scalesPresent;
+}

--- a/src/peripherals/scales.cpp
+++ b/src/peripherals/scales.cpp
@@ -42,32 +42,28 @@ void scalesInit(float scalesF1, float scalesF2) {
 }
 
 void scalesTare(void) {
-  if(scalesPresent) {
-    #if defined(SINGLE_HX711_CLOCK)
-      if (LoadCells.is_ready()) LoadCells.tare(5);
-    #else
-      if (LoadCell_1.wait_ready_timeout(300) && LoadCell_2.wait_ready_timeout(300)) {
-        LoadCell_1.tare(2);
-        LoadCell_2.tare(2);
-      }
-    #endif
-  }
+  #if defined(SINGLE_HX711_CLOCK)
+    if (LoadCells.is_ready()) LoadCells.tare(5);
+  #else
+    if (LoadCell_1.wait_ready_timeout(300) && LoadCell_2.wait_ready_timeout(300)) {
+      LoadCell_1.tare(2);
+      LoadCell_2.tare(2);
+    }
+  #endif
 }
 
 float scalesGetWeight(void) {
   float currentWeight = 0;
 
-  if(scalesPresent) {
-    #if defined(SINGLE_HX711_CLOCK)
-      if (LoadCells.is_ready()) {
-        float values[2];
-        LoadCells.get_units(values);
-        currentWeight = values[0] + values[1];
-      }
-    #else
-      currentWeight = LoadCell_1.get_units() + LoadCell_2.get_units();
-    #endif
-  }
+  #if defined(SINGLE_HX711_CLOCK)
+    if (LoadCells.is_ready()) {
+      float values[2];
+      LoadCells.get_units(values);
+      currentWeight = values[0] + values[1];
+    }
+  #else
+    currentWeight = LoadCell_1.get_units() + LoadCell_2.get_units();
+  #endif
 
   return currentWeight;
 }

--- a/src/peripherals/scales.h
+++ b/src/peripherals/scales.h
@@ -4,5 +4,6 @@
 void scalesInit(float scalesF1, float scalesF2);
 void scalesTare(void);
 float scalesGetWeight(void);
+bool scalesIsPresent(void);
 
 #endif


### PR DESCRIPTION
Had a stab at modifying the brewDetect and weighting code because there was a lot of coupling between detecting brew and weight calculations. 

Pulling up the concept of a `shotWeight` that is calculated only during brewTime being active. 

This simplifies a lot the lcdRefresh() code as well as the brewDetect code. 

I tested this on my coffee machine and it works fine. I tested it with weight / flow estimation. 

⚠️ I don't have scales so it would be good for someone with scales to flush and test before merging. 