### PR TITLE
Smaller fixes 2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ default_envs = blackpill
 
 [env:blackpill]
 framework = arduino
-platform = ststm32
+platform = ststm32@15.4.1
 board = blackpill_f411ce
 extra_scripts = pre:auto-version.py
 upload_protocol = stlink
@@ -21,13 +21,13 @@ debug_tool = stlink
 monitor_speed = 115200
 lib_compat_mode = strict
 lib_deps =
-	robtillaart/ADS1X15 @ 0.3.6
-	khoih-prog/FlashStorage_STM32 @ ^1.2.0
-	seithan/Easy Nextion Library@^1.0.6
-	adafruit/MAX6675 library@^1.1.0
-	; adafruit/Adafruit MAX31855 library@^1.3.0
-	https://github.com/banoz/PSM.Library.git
-	https://github.com/banoz/HX711.git
+	robtillaart/ADS1X15@0.3.7
+	khoih-prog/FlashStorage_STM32@1.2.0
+	seithan/Easy Nextion Library@1.0.6
+	adafruit/MAX6675 library@1.1.0
+	; adafruit/Adafruit MAX31855 library@1.3.0
+	https://github.com/banoz/PSM.Library.git#8f87ae0a67ace095c43bdbc661ffea72d4664b4c
+	https://github.com/banoz/HX711.git#cf81533c54abe259ef61d457d7db6eef94f6ea25
 
 build_flags =
 	-DPIO_FRAMEWORK_ARDUINO_ENABLE_CDC
@@ -39,7 +39,7 @@ build_flags =
 	-Wdouble-promotion -Wall
 
 [env:test]
-platform = native
+platform = native@1.2.1
 build_flags = -std=gnu++11 -include test/mock.h
 lib_deps =
 	ArduinoFake

--- a/platformio.ini
+++ b/platformio.ini
@@ -40,7 +40,7 @@ build_flags =
 
 [env:test]
 platform = native
-build_flags = -std=gnu++11 -include mock.h
+build_flags = -std=gnu++11 -include test/mock.h
 lib_deps =
 	ArduinoFake
 test_build_src=true


### PR DESCRIPTION
- First commit fixes tests, something has changed under the hood and `-include` build flag now requires path relative to the top level dir
- To prevent ^^^^ this to happen again, I freezed all libs and deps at the current versions in the next commit, the only thing which is floating still is the platformio itself.
- Without having the deps freezed it's completely random. Platformio downloads the newest versions of everything during the first build and leave it like that unless user deletes the .pio dir or updates the deps manually. 
- Dependencies can be easily listed with `pio pkg list` and `pio pkg outdated` checks for updates      