### PR TITLE
PCB scales calibration fix

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -123,6 +123,16 @@ build_flags =
 	-DPIN_SERIAL2_RX=PA3
 	-DPIN_SERIAL2_TX=PA2
 
+[env:scales-pcb-single-clock-stlink]
+extends = env:blackpill-core
+custom_src_dir = scales-calibration
+build_flags =
+	-DSINGLE_BOARD
+	-DSINGLE_HX711_CLOCK
+	-DENABLE_HWSERIAL2
+	-DPIN_SERIAL2_RX=PA3
+	-DPIN_SERIAL2_TX=PA2
+
 [env:scales-single-clock-dfu]
 extends = env:scales-single-clock-stlink
 upload_protocol = dfu
@@ -131,6 +141,15 @@ upload_protocol = dfu
 extends = env:blackpill-core
 custom_src_dir = scales-calibration
 build_flags =
+	-DENABLE_HWSERIAL2
+	-DPIN_SERIAL2_RX=PA3
+	-DPIN_SERIAL2_TX=PA2
+
+[env:scales-pcb-dual-clock-stlink]
+extends = env:blackpill-core
+custom_src_dir = scales-calibration
+build_flags =
+	-DSINGLE_BOARD
 	-DENABLE_HWSERIAL2
 	-DPIN_SERIAL2_RX=PA3
 	-DPIN_SERIAL2_TX=PA2

--- a/scales-calibration/scales-calibration.ino
+++ b/scales-calibration/scales-calibration.ino
@@ -35,6 +35,10 @@ EasyNex myNex(UART_LCD);
 
 void setup() {
   myNex.begin(115200);
+
+  #if defined(SINGLE_BOARD)
+    pinMode(relayPin, OUTPUT);
+  #endif
   digitalWrite(relayPin, LOW);
 
   while (myNex.readNumber("initCheck") != 100 )


### PR DESCRIPTION
Realized that calibrating scales did not have a task and there is a bug that prevented the boiler from turning off while calibrating scales with the PCB.

Wasn't sure how to append build_flags rather than overwrite. If there is a way to append it would be nice to extend off a scales single/dual base.