### PR TITLE
Don't openValve with DreamSteam disabled

### DIFF
--- a/src/functional/just_do_coffee.cpp
+++ b/src/functional/just_do_coffee.cpp
@@ -92,11 +92,10 @@ void steamCtrl(eepromValues_t &runningCfg, SensorState &currentState, bool brewA
   }else if ((currentState.pressure <= 9.f) && (currentState.temperature > STEAM_WAND_HOT_WATER_TEMP) && (currentState.temperature <= STEAM_TEMPERATURE)) {
     setBoilerOn();
     if (currentState.pressure < 1.5f) {
-      #if not defined SINGLE_BOARD
-        openValve();
-      #endif
-
       #ifndef DREAM_STEAM_DISABLED
+        #if not defined SINGLE_BOARD
+          openValve();
+        #endif
         setPumpToRawValue(5);
       #endif
     }


### PR DESCRIPTION
This prevents opening the solenoid while steaming (and releasing steam from the group head) in lego builds on non-gaggia machines. It shouldn’t have any negative effects, assuming the only purpose for openValve was to power up the dimmer, which is moot if user doesn’t want steam boost.