### PR TITLE
Show shot weight on finish

### DIFF
--- a/src/gaggiuino.h
+++ b/src/gaggiuino.h
@@ -33,7 +33,7 @@
 #define TRAY_FULL_THRESHOLD     700.f
 #define HEALTHCHECK_EVERY       30000 // system checks happen every 30sec
 #define BOILER_FILL_TIMEOUT     5000UL
-
+#define BREW_DETECT_DEBOUNCE    500
 
 
 typedef enum {
@@ -62,6 +62,7 @@ unsigned long scalesTimer = 0;
 unsigned long flowTimer = 0;
 unsigned long trayTimer = millis();
 unsigned long systemHealthTimer = 0;
+unsigned long brewDebounceTimer = 0;
 
 //scales vars
 float previousWeight  = 0;
@@ -70,6 +71,7 @@ bool tareDone         = false;
 // brew detection vars
 bool brewActive = false;
 bool nonBrewModeActive = false;
+bool stoppedOnWeight = false;
 
 //PP&PI variables
 int preInfusionFinishedPhaseIdx = 3;

--- a/src/gaggiuino.ino
+++ b/src/gaggiuino.ino
@@ -292,7 +292,7 @@ static void lcdRefresh(void) {
 
   #if defined DEBUG_ENABLED && defined stm32f411xx
     lcdShowDebug(readTempSensor(), getAdsError());
-#endif
+  #endif
 
     /*LCD timer and warmup*/
     if (brewActive) {
@@ -557,7 +557,7 @@ static void brewParamsReset(void) {
   tareDone                                    = false;
   currentState.pumpFlow                       = 0.f;
   previousWeight                              = 0.f;
-  currentState.weight                         = 0.f; 
+  currentState.weight                         = 0.f;
   currentState.liquidPumped                   = 0.f;
   preinfusionFinished                         = false;
   brewingTimer                                = millis();


### PR DESCRIPTION
Shows and holds shot weight on graph screen after brewing finishes with estimation for drips after brewing stops. In the current release branch weight on the graph screen goes to 0 as soon as brewing ends.

This functionality was present in commit cd9b4a9 of the dev branch, but got removed when stop conditions moved into profiling phases in commit 04138bd. I used the same method as cd9b4a9 to estimate drips after brewing. 


Also adjusted systemHealthCheck logic so the check can run if brewing stopped on weight, but the brew button is still depressed for those times I forget to flip the brew switch off.
