### PR TITLE
Allow EEPROM versioning to upgrade to latest

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -175,6 +175,9 @@ build_flags =
 	-DPIN_SERIAL2_TX=PA2
 	-DBEAUTIFY_GRAPH
 	-Wdouble-promotion -Wall
+	-O0
+build_unflags =
+	-Os
 
 [env:blackpill-dfu]
 extends = env:blackpill-core

--- a/src/eeprom_data/eeprom_data.h
+++ b/src/eeprom_data/eeprom_data.h
@@ -4,10 +4,32 @@
 #include <Arduino.h>
 #include "log.h"
 
-#define EEPROM_DATA_VERSION 4
+/**
+ * current data version definition below
+ *
+ * changing the schema requires bumping version number. this forces a schema update
+ * on boards with a lower version after flash. to make this graceful for users:
+ * - archive the current version in its corresponding header in legacy/
+ * - in that header, make sure to register the upgrade function for
+ *   the loader to pick it up
+ * - bump up the version in eeprom_metadata.h
+ * - make schema changes
+ *
+ * adding fields to data below shouldn't require changes to legacy upgrade
+ * functions - they just won't populate the new field, and it will use
+ * default value.
+ *
+ * removing fields might require deleting assignments in existing legacy
+ * functions that reference them. this will pop up as a compile time failure
+ */
 
+/**
+ * Version 5:
+ * - Introduced steamSetpoint
+*/
 struct eepromValues_t {
   uint16_t setpoint;
+  uint16_t steamSetpoint;
   uint16_t offsetTemp;
   uint16_t hpwr;
   uint16_t mainDivider;
@@ -46,13 +68,6 @@ struct eepromValues_t {
   float    shotDose;
   float    shotStopOnCustomWeight;
   uint16_t shotPreset;
-};
-
-struct eepromMetadata_t {
-  uint16_t version;
-  unsigned long timestamp;
-  struct eepromValues_t values;
-  uint32_t versionTimestampXOR;
 };
 
 void eepromInit(void);

--- a/src/eeprom_data/eeprom_metadata.h
+++ b/src/eeprom_data/eeprom_metadata.h
@@ -1,0 +1,45 @@
+#ifndef EEPROM_METADATA_H
+#define EEPROM_METADATA_H
+
+#include <Arduino.h>
+
+#define EEPROM_DATA_VERSION 5
+
+#define EEPROM_METADATA_T(__eepromValues_tName) \
+  {                                             \
+    uint16_t version;                           \
+    unsigned long timestamp;                    \
+    struct __eepromValues_tName values;         \
+    uint32_t versionTimestampXOR;               \
+  }
+
+struct eepromMetadata_t EEPROM_METADATA_T(eepromValues_t);
+
+#define EEPROM_METADATA_LOADER(__eepromDataVersion, __eepromMetadata_tName, __upgradeSchema_fName)  \
+  (eepromValues_t & targetValues)                                                                   \
+  {                                                                                                 \
+    __eepromMetadata_tName eepromMetadata;                                                          \
+    EEPROM.get(0, eepromMetadata);                                                                  \
+    uint32_t XOR = eepromMetadata.timestamp ^ eepromMetadata.version;                               \
+    if (eepromMetadata.version != __eepromDataVersion || eepromMetadata.versionTimestampXOR != XOR) \
+    {                                                                                               \
+      return false;                                                                                 \
+    }                                                                                               \
+    return __upgradeSchema_fName(targetValues, eepromMetadata.values);                              \
+  }
+
+bool (*legacyEepromDataLoaders[EEPROM_DATA_VERSION])(eepromValues_t &);
+
+#define REGISTER_LEGACY_EEPROM_DATA(version, eepromData_tName, upgradeSchema_fName)       \
+  /* declare & define metadata */                                                         \
+  struct _eepromMetadata_t_v##version EEPROM_METADATA_T(eepromData_tName);                \
+  /* define loader function */                                                            \
+  static bool _loadEepromMetadata_v##version                                              \
+      EEPROM_METADATA_LOADER(version, _eepromMetadata_t_v##version, upgradeSchema_fName); \
+  /* register loader ptr in array */                                                      \
+  void __attribute__((constructor)) _registerEepromMetadataLoader_v##version()            \
+  {                                                                                       \
+    legacyEepromDataLoaders[version] = &_loadEepromMetadata_v##version;                   \
+  }
+
+#endif

--- a/src/eeprom_data/legacy/eeprom_data_v4.h
+++ b/src/eeprom_data/legacy/eeprom_data_v4.h
@@ -1,0 +1,98 @@
+#ifndef EEPROM_DATA_V4_H
+#define EEPROM_DATA_V4_H
+
+#include "../eeprom_data.h"
+#include "../eeprom_metadata.h"
+
+/**
+ * Version 4:
+ * - added switchPhaseOnThreshold
+*/
+struct eepromValues_t_v4 {
+  uint16_t setpoint;
+  uint16_t offsetTemp;
+  uint16_t hpwr;
+  uint16_t mainDivider;
+  uint16_t brewDivider;
+  uint16_t pressureProfilingStart;
+  uint16_t pressureProfilingFinish;
+  uint16_t pressureProfilingHold;
+  uint16_t pressureProfilingLength;
+  bool     pressureProfilingState;
+  bool     preinfusionState;
+  uint16_t preinfusionSec;
+  uint16_t preinfusionBar;
+  uint16_t preinfusionSoak;
+  uint16_t preinfusionRamp;
+  bool     preinfusionFlowState;
+  float    preinfusionFlowVol;
+  uint16_t preinfusionFlowTime;
+  uint16_t preinfusionFlowSoakTime;
+  uint16_t preinfusionFlowPressureTarget;
+  bool     flowProfileState;
+  float    flowProfileStart;
+  float    flowProfileEnd;
+  uint16_t flowProfilePressureTarget;
+  uint16_t flowProfileCurveSpeed;
+  uint16_t powerLineFrequency;
+  uint16_t lcdSleep;
+  bool     warmupState;
+  bool     homeOnShotFinish;
+  bool     graphBrew;
+  bool     brewDeltaState;
+  bool     switchPhaseOnThreshold;
+  int      scalesF1;
+  int      scalesF2;
+  float    pumpFlowAtZero;
+  bool     stopOnWeightState;
+  float    shotDose;
+  float    shotStopOnCustomWeight;
+  uint16_t shotPreset;
+};
+
+static bool upgradeSchema_v4(eepromValues_t &targetValues, eepromValues_t_v4 &loadedValues) {
+  targetValues.setpoint = loadedValues.setpoint;
+  targetValues.offsetTemp = loadedValues.offsetTemp;
+  targetValues.hpwr = loadedValues.hpwr;
+  targetValues.mainDivider = loadedValues.mainDivider;
+  targetValues.brewDivider = loadedValues.brewDivider;
+  targetValues.pressureProfilingStart = loadedValues.pressureProfilingStart;
+  targetValues.pressureProfilingFinish = loadedValues.pressureProfilingFinish;
+  targetValues.pressureProfilingHold = loadedValues.pressureProfilingHold;
+  targetValues.pressureProfilingLength = loadedValues.pressureProfilingLength;
+  targetValues.pressureProfilingState = loadedValues.pressureProfilingState;
+  targetValues.preinfusionState = loadedValues.preinfusionState;
+  targetValues.preinfusionSec = loadedValues.preinfusionSec;
+  targetValues.preinfusionBar = loadedValues.preinfusionBar;
+  targetValues.preinfusionSoak = loadedValues.preinfusionSoak;
+  targetValues.preinfusionRamp = loadedValues.preinfusionRamp;
+  targetValues.preinfusionFlowState = loadedValues.preinfusionFlowState;
+  targetValues.preinfusionFlowVol = loadedValues.preinfusionFlowVol;
+  targetValues.preinfusionFlowTime = loadedValues.preinfusionFlowTime;
+  targetValues.preinfusionFlowSoakTime = loadedValues.preinfusionFlowSoakTime;
+  targetValues.preinfusionFlowPressureTarget = loadedValues.preinfusionFlowPressureTarget;
+  targetValues.flowProfileState = loadedValues.flowProfileState;
+  targetValues.flowProfileStart = loadedValues.flowProfileStart;
+  targetValues.flowProfileEnd = loadedValues.flowProfileEnd;
+  targetValues.flowProfilePressureTarget = loadedValues.flowProfilePressureTarget;
+  targetValues.flowProfileCurveSpeed = loadedValues.flowProfileCurveSpeed;
+  targetValues.powerLineFrequency = loadedValues.powerLineFrequency;
+  targetValues.lcdSleep = loadedValues.lcdSleep;
+  targetValues.warmupState = loadedValues.warmupState;
+  targetValues.homeOnShotFinish = loadedValues.homeOnShotFinish;
+  targetValues.graphBrew = loadedValues.graphBrew;
+  targetValues.brewDeltaState = loadedValues.brewDeltaState;
+  targetValues.switchPhaseOnThreshold = loadedValues.switchPhaseOnThreshold;
+  targetValues.scalesF1 = loadedValues.scalesF1;
+  targetValues.scalesF2 = loadedValues.scalesF2;
+  targetValues.pumpFlowAtZero = loadedValues.pumpFlowAtZero;
+  targetValues.stopOnWeightState = loadedValues.stopOnWeightState;
+  targetValues.shotDose = loadedValues.shotDose;
+  targetValues.shotStopOnCustomWeight = loadedValues.shotStopOnCustomWeight;
+  targetValues.shotPreset = loadedValues.shotPreset;
+  return true;
+}
+
+REGISTER_LEGACY_EEPROM_DATA(4, eepromValues_t_v4, upgradeSchema_v4)
+
+#endif

--- a/src/functional/descale.h
+++ b/src/functional/descale.h
@@ -3,7 +3,7 @@
 
 #include "../peripherals/pump.h"
 #include "../lcd/lcd.h"
-#include "../eeprom_data.h"
+#include "../eeprom_data/eeprom_data.h"
 #include "../sensors_state.h"
 #include "just_do_coffee.h"
 #include <Arduino.h>

--- a/src/functional/just_do_coffee.h
+++ b/src/functional/just_do_coffee.h
@@ -4,7 +4,7 @@
 #include "../utils.h"
 #include "../peripherals/peripherals.h"
 #include "../peripherals/pump.h"
-#include "../eeprom_data.h"
+#include "../eeprom_data/eeprom_data.h"
 #include "../sensors_state.h"
 #include <Arduino.h>
 

--- a/src/functional/predictive_weight.h
+++ b/src/functional/predictive_weight.h
@@ -3,7 +3,7 @@
 
 #include "../profiling_phases.h"
 #include "../sensors_state.h"
-#include "../eeprom_data.h"
+#include "../eeprom_data/eeprom_data.h"
 
 class PredictiveWeight {
 private:

--- a/src/gaggiuino.h
+++ b/src/gaggiuino.h
@@ -3,7 +3,7 @@
 
 #include "profiling_phases.h"
 #include "log.h"
-#include "eeprom_data.h"
+#include "eeprom_data/eeprom_data.h"
 #include "lcd/lcd.h"
 #include "peripherals/pump.h"
 #include "peripherals/pressure_sensor.h"

--- a/src/lcd/lcd.h
+++ b/src/lcd/lcd.h
@@ -2,7 +2,7 @@
 #define LCD_H
 
 #include <EasyNextionLibrary.h>
-#include "eeprom_data.h"
+#include "eeprom_data/eeprom_data.h"
 
 extern volatile int lcdCurrentPageId;
 extern volatile int lcdLastCurrentPageId;

--- a/src/profiling_phases.h
+++ b/src/profiling_phases.h
@@ -3,7 +3,7 @@
 
 #include "utils.h"
 #include "sensors_state.h"
-#include "eeprom_data.h"
+#include "eeprom_data/eeprom_data.h"
 
 enum PHASE_TYPE {
   PHASE_TYPE_FLOW,


### PR DESCRIPTION
    Allow EEPROM versioning to upgrade to latest

    This change introduces a mechanism to preserve older versions of the
    settings in code, with a process to upgrade to the current version on
    flash.

    It also allows for arbitrary manipulation of the variables during
    version bumps, for instance, to transform a stored data type or data
    units, or to selectively override some stored settings with defaults. I
    expect this to help changes such as PZ range.

    It makes the assumption that versions always increase. It does not
    handle versions 1-3, as I tried to reconstruct them from git history,
    but couldn't find a consistent schema for most of them.

As a proof of concept (and paving the way for the feature I'm working on) I added `steamSetpoint` to the schema.

This also includes the compiler optimization changes we discussed, as the optimizer seems to remove branches when they depend on the state of the EEPROM data.
