### PR TITLE
Fix transition timing bug

### DIFF
--- a/src/functional/profiling_phases.cpp
+++ b/src/functional/profiling_phases.cpp
@@ -89,8 +89,7 @@ void PhaseProfiler::updatePhase(long timeInShot, SensorState& state) {
 
   currentPhaseIdx += 1;
   long maxTimeAdvancement = (phases.phases[phaseIdx].stopConditions.time > 0) ? phases.phases[phaseIdx].stopConditions.time : timeInPhase;
-  phaseChangedSnapshot = ShotSnapshot{phaseChangedSnapshot.timeInShot, state.pressure, state.pumpFlow, state.temperature, state.shotWeight, state.waterPumped};
-  phaseChangedSnapshot.timeInShot += fmin(timeInPhase, maxTimeAdvancement);
+  phaseChangedSnapshot = ShotSnapshot{timeInShot, state.pressure, state.pumpFlow, state.temperature, state.shotWeight, state.waterPumped};
   updatePhase(timeInShot, state);
 }
 


### PR DESCRIPTION
Also simplifies the timing transitions to always use timeInShot when the transition happens. 