### PR TITLE
Lower pump flow prediction function for pressures < 3bar

### DIFF
--- a/src/functional/profiling_phases.cpp
+++ b/src/functional/profiling_phases.cpp
@@ -88,7 +88,6 @@ void PhaseProfiler::updatePhase(long timeInShot, SensorState& state) {
   }
 
   currentPhaseIdx += 1;
-  long maxTimeAdvancement = (phases.phases[phaseIdx].stopConditions.time > 0) ? phases.phases[phaseIdx].stopConditions.time : timeInPhase;
   phaseChangedSnapshot = ShotSnapshot{timeInShot, state.pressure, state.pumpFlow, state.temperature, state.shotWeight, state.waterPumped};
   updatePhase(timeInShot, state);
 }

--- a/src/peripherals/pump.cpp
+++ b/src/peripherals/pump.cpp
@@ -4,12 +4,13 @@
 #include "../utils.h"
 
 PSM pump(zcPin, dimmerPin, PUMP_RANGE, ZC_MODE, 2, 4);
-
-float pressureInefficiencyConstant1 = -0.106f;
-float pressureInefficiencyConstant2 = -0.00785f;
-float pressureInefficiencyConstant3 = -0.000521f;
-float pressureInefficiencyConstant4 =  0.0000832f;
-float pressureInefficiencyConstant5 = -0.00000466f;
+float pressureInefficiencyConstant0 = -0.128f;
+float pressureInefficiencyConstant1 =  0.00222;
+float pressureInefficiencyConstant2 = -0.00184f;
+float pressureInefficiencyConstant3 =  0.0000915f;
+float pressureInefficiencyConstant4 =  0.00000594f;
+float pressureInefficiencyConstant5 = -0.000000798f;
+float pressureInefficiencyConstant6 =  0.0000000186f;
 
 float flowPerClickAtZeroBar = 0.29f;
 short maxPumpClicksPerSecond = 50;
@@ -81,8 +82,7 @@ long getAndResetClickCounter(void) {
 //
 // The function is split to compensate for the rapid decline in fpc at low pressures
 float getPumpFlowPerClick(float pressure) {
-    float fpc = (flowPerClickAtZeroBar + pressureInefficiencyConstant1) + (pressureInefficiencyConstant2 + (pressureInefficiencyConstant3 + (pressureInefficiencyConstant4 + pressureInefficiencyConstant5 * pressure) * pressure) * pressure) * pressure;
-    if (pressure <= 2.f) fpc = mapRange(pressure,0.f, 2.f, 0.275f, 0.185f, 3, EASE_IN_OUT);
+    float fpc = (flowPerClickAtZeroBar + pressureInefficiencyConstant0) + (pressureInefficiencyConstant1 + (pressureInefficiencyConstant2 + (pressureInefficiencyConstant3 + (pressureInefficiencyConstant4 + (pressureInefficiencyConstant5 + pressureInefficiencyConstant6 * pressure) * pressure) * pressure) * pressure) * pressure) * pressure;
     return 50.0f * fmaxf(fpc, 0.f) / (float)maxPumpClicksPerSecond;
 }
 

--- a/tests/test_pump.cpp
+++ b/tests/test_pump.cpp
@@ -7,7 +7,7 @@ void TEST_ASSERT_EQUAL_FLOAT_ACCURACY(float expected, float actual, int digits) 
 }
 
 void test_pump_clicks_for_flow_correct_binary_search(void) {
-    TEST_ASSERT_EQUAL_FLOAT_ACCURACY(27, getClicksPerSecondForFlow(5, 2), 0);
+    TEST_ASSERT_EQUAL_FLOAT_ACCURACY(31, getClicksPerSecondForFlow(5, 2), 0);
     TEST_ASSERT_EQUAL_FLOAT_ACCURACY(50, getClicksPerSecondForFlow(10, 9), 0);
     TEST_ASSERT_EQUAL_FLOAT_ACCURACY(0, getClicksPerSecondForFlow(0, 0), 0);
 }


### PR DESCRIPTION
### Lower the prediction for lower pressures (<3bar)

#### PZ=0.419 (Red = Before / Blue = After)
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/6816533/206623562-8844535e-2f04-460d-9ca5-495a7b972bde.png">

#### PZ=0.295 (Red = Before / Blue = After)
<img width="1135" alt="image" src="https://user-images.githubusercontent.com/6816533/206623813-e6317e8a-e0ed-4f9c-92a8-4fcb5b2df601.png">
