### PR TITLE
Fix updating of CurrentPhase

### DIFF
--- a/src/functional/profiling_phases.cpp
+++ b/src/functional/profiling_phases.cpp
@@ -104,6 +104,7 @@ bool PhaseProfiler::isFinished() {
 void PhaseProfiler::reset() {
   currentPhaseIdx = 0;
   phaseChangedSnapshot = ShotSnapshot{0, 0, 0, 0, 0, 0};
+  currentPhase.update(0, phases.phases[0], 0);
 }
 
 void PhaseProfiler::updateGlobalStopConditions(float weight, long time, float waterVolume) {

--- a/src/functional/profiling_phases.cpp
+++ b/src/functional/profiling_phases.cpp
@@ -3,23 +3,23 @@
 //----------------------------------------------------------------------//
 //------------------------------ Phase ---------------------------------//
 //----------------------------------------------------------------------//
-float Phase::getTarget(unsigned long timeInPhase) {
+float Phase::getTarget(unsigned long timeInPhase) const {
   long transitionTime = fmax(0L, target.time > 0L ? target.time : stopConditions.time);
   return mapRange(timeInPhase, 0.f, transitionTime, target.start, target.end, 1, target.curve);
 }
 
-float Phase::getRestriction() {
+float Phase::getRestriction() const {
   return restriction;
 }
 
-bool Phase::isStopConditionReached(SensorState& currentState, unsigned long timeInShot, ShotSnapshot stateAtPhaseStart) {
+bool Phase::isStopConditionReached(SensorState& currentState, unsigned long timeInShot, ShotSnapshot stateAtPhaseStart) const {
   return stopConditions.isReached(currentState, timeInShot, stateAtPhaseStart);
 }
 
 //----------------------------------------------------------------------//
 //-------------------------- StopConditions ----------------------------//
 //----------------------------------------------------------------------//
-bool PhaseStopConditions::isReached(SensorState& state, long timeInShot, ShotSnapshot stateAtPhaseStart) {
+bool PhaseStopConditions::isReached(SensorState& state, long timeInShot, ShotSnapshot stateAtPhaseStart) const {
   float flow = state.weight > 0.4f ? state.weightFlow : state.smoothedPumpFlow;
   float stopDelta = flow / 2.f;
 
@@ -44,24 +44,24 @@ bool GlobalStopConditions::isReached(SensorState& state, long timeInShot) {
 //----------------------------------------------------------------------//
 //--------------------------- CurrentPhase -----------------------------//
 //----------------------------------------------------------------------//
-CurrentPhase::CurrentPhase(int index, Phase& phase, unsigned long timeInPhase) : index(index), phase{ phase }, timeInPhase(timeInPhase) {}
+CurrentPhase::CurrentPhase(int index, const Phase& phase, unsigned long timeInPhase) : index(index), phase{ &phase }, timeInPhase(timeInPhase) {}
 CurrentPhase::CurrentPhase(const CurrentPhase& currentPhase) : index(currentPhase.index), phase{ currentPhase.phase }, timeInPhase(currentPhase.timeInPhase) {}
 
-Phase CurrentPhase::getPhase() { return phase; }
+Phase CurrentPhase::getPhase() { return *phase; }
 
-PHASE_TYPE CurrentPhase::getType() { return phase.type; }
+PHASE_TYPE CurrentPhase::getType() { return phase->type; }
 
 int CurrentPhase::getIndex() { return index; }
 
 long CurrentPhase::getTimeInPhase() { return timeInPhase; }
 
-float CurrentPhase::getTarget() { return phase.getTarget(timeInPhase); }
+float CurrentPhase::getTarget() { return phase->getTarget(timeInPhase); }
 
-float CurrentPhase::getRestriction() { return phase.getRestriction(); }
+float CurrentPhase::getRestriction() { return phase->getRestriction(); }
 
-void CurrentPhase::update(int index, Phase& phase, unsigned long timeInPhase) {
+void CurrentPhase::update(int index, const Phase& phase, unsigned long timeInPhase) {
   CurrentPhase::index = index;
-  CurrentPhase::phase = phase;
+  CurrentPhase::phase = &phase;
   CurrentPhase::timeInPhase = timeInPhase;
 }
 

--- a/src/functional/profiling_phases.h
+++ b/src/functional/profiling_phases.h
@@ -28,7 +28,7 @@ struct PhaseStopConditions {
   float weight = -1; //example: when pushed weight >0 stop this phase)
   float waterPumpedInPhase = -1;
 
-  bool isReached(SensorState& state, long timeInShot, ShotSnapshot stateAtPhaseStart);
+  bool isReached(SensorState& state, long timeInShot, ShotSnapshot stateAtPhaseStart) const;
 };
 
 struct GlobalStopConditions {
@@ -56,19 +56,19 @@ struct Phase {
   float restriction;
   PhaseStopConditions stopConditions;
 
-  float getTarget(unsigned long timeInPhase);
-  float getRestriction();
-  bool isStopConditionReached(SensorState& currentState, unsigned long timeInShot, ShotSnapshot stateAtPhaseStart);
+  float getTarget(unsigned long timeInPhase) const;
+  float getRestriction() const;
+  bool isStopConditionReached(SensorState& currentState, unsigned long timeInShot, ShotSnapshot stateAtPhaseStart) const;
 };
 
 class CurrentPhase {
 private:
   int index;
-  Phase& phase;
+  const Phase* phase;
   unsigned long timeInPhase;
 
 public:
-  CurrentPhase(int index, Phase& phase, unsigned long timeInPhase);
+  CurrentPhase(int index, const Phase& phase, unsigned long timeInPhase);
   CurrentPhase(const CurrentPhase& currentPhase);
 
   Phase getPhase();
@@ -77,7 +77,7 @@ public:
   long getTimeInPhase();
   float getTarget();
   float getRestriction();
-  void update(int index, Phase& phase, unsigned long timeInPhase);
+  void update(int index, const Phase& phase, unsigned long timeInPhase);
 };
 
 struct Phases {

--- a/tests/test_pressure_profiler.cpp
+++ b/tests/test_pressure_profiler.cpp
@@ -62,6 +62,39 @@ void test_current_phase_calculation(void)
     phaseProfiler.updatePhase(12500, state);
     TEST_ASSERT_EQUAL(3, phaseProfiler.getCurrentPhase().getIndex());
     TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getTimeInPhase());
+
+    // Reset and run the same tests again
+    phaseProfiler.reset();
+    phaseProfiler.updatePhase(0, state);
+    TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getIndex());
+    TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getTimeInPhase());
+
+    phaseProfiler.updatePhase(550, state);
+    TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getIndex());
+    TEST_ASSERT_EQUAL(550, phaseProfiler.getCurrentPhase().getTimeInPhase());
+
+    phaseProfiler.updatePhase(1000, state);
+    TEST_ASSERT_EQUAL(1, phaseProfiler.getCurrentPhase().getIndex());
+    TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getTimeInPhase());
+
+    phaseProfiler.updatePhase(5000, state);
+    TEST_ASSERT_EQUAL(1, phaseProfiler.getCurrentPhase().getIndex());
+    TEST_ASSERT_EQUAL(4000, phaseProfiler.getCurrentPhase().getTimeInPhase());
+
+    // phase switch triggered on 11.5sec
+    phaseProfiler.updatePhase(11500, state);
+    TEST_ASSERT_EQUAL(2, phaseProfiler.getCurrentPhase().getIndex());
+    TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getTimeInPhase());
+
+    // still in the same phase as it should last 1000msec
+    phaseProfiler.updatePhase(12499, state);
+    TEST_ASSERT_EQUAL(2, phaseProfiler.getCurrentPhase().getIndex());
+    TEST_ASSERT_EQUAL(999, phaseProfiler.getCurrentPhase().getTimeInPhase());
+
+    // still in the same phase as it should last 1000msec
+    phaseProfiler.updatePhase(12500, state);
+    TEST_ASSERT_EQUAL(3, phaseProfiler.getCurrentPhase().getIndex());
+    TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getTimeInPhase());
 }
 
 void test_get_pressure_for_phase(void)

--- a/tests/test_pressure_profiler.cpp
+++ b/tests/test_pressure_profiler.cpp
@@ -62,39 +62,6 @@ void test_current_phase_calculation(void)
     phaseProfiler.updatePhase(12500, state);
     TEST_ASSERT_EQUAL(3, phaseProfiler.getCurrentPhase().getIndex());
     TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getTimeInPhase());
-
-    // Reset and run the same tests again
-    phaseProfiler.reset();
-    phaseProfiler.updatePhase(0, state);
-    TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getIndex());
-    TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getTimeInPhase());
-
-    phaseProfiler.updatePhase(550, state);
-    TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getIndex());
-    TEST_ASSERT_EQUAL(550, phaseProfiler.getCurrentPhase().getTimeInPhase());
-
-    phaseProfiler.updatePhase(1000, state);
-    TEST_ASSERT_EQUAL(1, phaseProfiler.getCurrentPhase().getIndex());
-    TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getTimeInPhase());
-
-    phaseProfiler.updatePhase(5000, state);
-    TEST_ASSERT_EQUAL(1, phaseProfiler.getCurrentPhase().getIndex());
-    TEST_ASSERT_EQUAL(4000, phaseProfiler.getCurrentPhase().getTimeInPhase());
-
-    // phase switch triggered on 11.5sec
-    phaseProfiler.updatePhase(11500, state);
-    TEST_ASSERT_EQUAL(2, phaseProfiler.getCurrentPhase().getIndex());
-    TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getTimeInPhase());
-
-    // still in the same phase as it should last 1000msec
-    phaseProfiler.updatePhase(12499, state);
-    TEST_ASSERT_EQUAL(2, phaseProfiler.getCurrentPhase().getIndex());
-    TEST_ASSERT_EQUAL(999, phaseProfiler.getCurrentPhase().getTimeInPhase());
-
-    // still in the same phase as it should last 1000msec
-    phaseProfiler.updatePhase(12500, state);
-    TEST_ASSERT_EQUAL(3, phaseProfiler.getCurrentPhase().getIndex());
-    TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getTimeInPhase());
 }
 
 void test_get_pressure_for_phase(void)
@@ -194,6 +161,28 @@ void test_phases_with_stop_conditions_and_skipped_phases() {
   TEST_ASSERT_EQUAL(2, profiler.getCurrentPhase().getIndex());
 }
 
+void test_phases_stay_constant() {
+  // Check that the phases stay constant after updating and resetting
+
+  phaseProfiler.reset();
+  phaseProfiler.updatePhase(0, state);
+  phaseProfiler.updatePhase(550, state);
+  phaseProfiler.updatePhase(1000, state);
+  phaseProfiler.updatePhase(12500, state);
+  phaseProfiler.reset();
+
+  TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getIndex());
+  TEST_ASSERT_EQUAL(0, phaseProfiler.getCurrentPhase().getTimeInPhase());
+
+  TEST_ASSERT_EQUAL(1000, phases.phases[0].stopConditions.time);
+  TEST_ASSERT_EQUAL(0, phases.phases[0].target.start);
+  TEST_ASSERT_EQUAL(2, phases.phases[0].target.end);
+
+  TEST_ASSERT_EQUAL(10000, phases.phases[1].stopConditions.time);
+  TEST_ASSERT_EQUAL(2, phases.phases[1].target.start);
+  TEST_ASSERT_EQUAL(2, phases.phases[1].target.end);
+}
+
 void runAllPressureProfilerTests() {
   RUN_TEST(test_current_phase_calculation);
   RUN_TEST(test_get_pressure_for_phase);
@@ -202,4 +191,5 @@ void runAllPressureProfilerTests() {
   RUN_TEST(test_phases_with_zero_duration_are_skipped);
   RUN_TEST(test_phases_with_weight_stop_condition);
   RUN_TEST(test_phases_with_stop_conditions_and_skipped_phases);
+  RUN_TEST(test_phases_stay_constant);
 }


### PR DESCRIPTION
Setting `CurrentPhase::phase = phase` changed the value of original phase, instead of updating the reference. Changing this to a pointer solves it.

This bug likely did not affect users, since the phases are reconstructed every time the LCD page changes.

