### PR TITLE
Use hardware scales to detect full boiler

### DIFF
--- a/src/gaggiuino.h
+++ b/src/gaggiuino.h
@@ -36,6 +36,7 @@
 #define HEALTHCHECK_EVERY       30000 // system checks happen every 30sec
 #define BOILER_FILL_TIMEOUT     8000UL
 #define BOILER_FILL_PRESSURE    1.8f
+#define BOILER_FILL_WEIGHT      3.f
 
 
 

--- a/src/gaggiuino.ino
+++ b/src/gaggiuino.ino
@@ -107,7 +107,7 @@ static void sensorsRead(void) {
   sensorsReadWeight();
   sensorsReadPressure();
   calculateWeightAndFlow();
-  fillBoiler(BOILER_FILL_PRESSURE);
+  fillBoiler(BOILER_FILL_PRESSURE, BOILER_FILL_WEIGHT);
 }
 
 static void sensorsReadTemperature(void) {
@@ -594,14 +594,14 @@ static void brewParamsReset(void) {
   phaseProfiler.reset();
 }
 
-void fillBoiler(float targetBoilerFullPressure) {
+void fillBoiler(float targetBoilerFullPressure, float outputWeightThreshold) {
 #if defined LEGO_VALVE_RELAY || defined SINGLE_BOARD
   static long elapsedTimeSinceStart = millis();
   lcdSetUpTime((millis() > elapsedTimeSinceStart) ? (int)((millis() - elapsedTimeSinceStart) / 1000) : 0);
   if (!startupInitFinished && lcdCurrentPageId == 0 && millis() - elapsedTimeSinceStart >= 3000) {
     unsigned long timePassed = millis() - elapsedTimeSinceStart;
 
-    if (currentState.smoothedPressure < targetBoilerFullPressure && timePassed <= BOILER_FILL_TIMEOUT) {
+    if (currentState.smoothedPressure < targetBoilerFullPressure && currentState.weight < outputWeightThreshold && timePassed <= BOILER_FILL_TIMEOUT) {
       lcdShowPopup("Filling boiler!");
       openValve();
       setPumpToRawValue(80);


### PR DESCRIPTION
If hardware scales are present they can be used to detect output from the grouphead. This provides another signal to detect that the boiler is full in the case that the pressure threshold has not been reached for whatever reason.