### PR TITLE
fix hot water when DreamSteam disabled

### DIFF
--- a/src/functional/just_do_coffee.cpp
+++ b/src/functional/just_do_coffee.cpp
@@ -115,6 +115,8 @@ void steamCtrl(eepromValues_t &runningCfg, SensorState &currentState, bool brewA
     setBoilerOff();
     #ifndef DREAM_STEAM_DISABLED
       (currentState.smoothedPressure < 1.8f) ? setPumpToRawValue(3) : setPumpOff();
+    #else
+      setPumpOff(); // pump can be on from hot water mode
     #endif
   }
 


### PR DESCRIPTION
currently flicking brew off leaves the pump running if steamCtrl doesn't control the pump for steam only