### PR TITLE
Use the correct pressure attributes

### DIFF
--- a/lib/Common/profiling_phases.cpp
+++ b/lib/Common/profiling_phases.cpp
@@ -47,8 +47,8 @@ bool PhaseStopConditions::isReached(SensorState& state, long timeInShot, ShotSna
 
   return (time >= 0L && timeInShot - stateAtPhaseStart.timeInShot >= (uint32_t) time) ||
     (weight > 0.f && state.shotWeight > weight - stopDelta) ||
-    (pressureAbove > 0.f && state.pressure > pressureAbove) ||
-    (pressureBelow > 0.f && state.pressure < pressureBelow) ||
+    (pressureAbove > 0.f && state.smoothedPressure > pressureAbove) ||
+    (pressureBelow > 0.f && state.smoothedPressure < pressureBelow) ||
     (waterPumpedInPhase > 0.f && state.waterPumped - stateAtPhaseStart.waterPumped > waterPumpedInPhase - stopDelta) ||
     (flowAbove > 0.f && state.smoothedPumpFlow > flowAbove) ||
     (flowBelow > 0.f && state.smoothedPumpFlow < flowBelow);

--- a/src/gaggiuino.h
+++ b/src/gaggiuino.h
@@ -35,7 +35,7 @@
 #define TRAY_FULL_THRESHOLD     700.f
 #define HEALTHCHECK_EVERY       30000 // system checks happen every 30sec
 #define BOILER_FILL_TIMEOUT     8000UL
-#define BOILER_FILL_PRESSURE    1.75f
+#define BOILER_FILL_PRESSURE    2.0f
 
 
 

--- a/src/gaggiuino.ino
+++ b/src/gaggiuino.ino
@@ -603,7 +603,7 @@ void fillBoiler(float targetBoilerFullPressure) {
     unsigned long timePassed = millis() - elapsedTimeSinceStart;
 
     if (timePassed <= BOILER_FILL_TIMEOUT
-    &&  (currentState.smoothedPressure < targetBoilerFullPressure || currentState.weight > 2.f))
+    &&  (currentState.pressure < targetBoilerFullPressure || currentState.weight > 2.f))
     {
       lcdShowPopup("Filling boiler!");
       openValve();


### PR DESCRIPTION
I'm not sure what the reasons for the choices were for the previous state but I've tried these changes and they work well for me.

The boiler fill still results in water being forced out of the grouphead confirming the boiler in indeed full when the steam wand is closed. But when the steam wand is open it runs until timeout. To me this suggests that this still achieves the desired effect but without having to wait for the `smoothedPressure` to reach the threshold. I could be wrong here and maybe more testing is needed to stop using `smoothedPressure` here... but for me at least (using the standard BoM) it isn't sensitive enough and doesn't behave reliably.

For the `StopConditions`, this seems more logical? We don't want to trigger the condition due to noise in the transducer. We only want to transition on steady state pressure, right?

Together these changes make both the `Boiler Fill` and `Switch on Threshold` behave reliably across a range of transducer hose lengths (20-60cm). I'm yet to try it with a capillary tube but I suspect that's irrelevant given it isn't standard BoM.