### PR TITLE
Improve GitHub Actions and fix implicit casts

### DIFF
--- a/.github/workflows/compile-sketch.yml
+++ b/.github/workflows/compile-sketch.yml
@@ -30,64 +30,60 @@ jobs:
         run: |
           eclint check $(sh .eclint-files.sh)
 
-  compile-sketch:
+  compile:
+    name: Compilation
     runs-on: ubuntu-latest
     timeout-minutes: 30
-
+    strategy:
+      fail-fast: false
+      matrix:
+        environment:
+          - name: Main
+            command: "gaggia-lego-stlink"
+          - name: Scales
+            command: "scales-calibration-dfu"
     steps:
-      - name: Checkout master
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Set up Python
-        uses: actions/setup-python@v1
-
+      - uses: actions/setup-python@v1
       - name: Install Platformio
         run: |
           python3 -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/master/scripts/get-platformio.py)"
-
-      - name: Build the main project
+      - name: Building ${{ matrix.environment.name }}
         run: |
-          ~/.platformio/penv/bin/platformio run -e gaggia-lego-stlink
+          ~/.platformio/penv/bin/platformio run -e ${{ matrix.environment.command }}
+        env:
+          PLATFORMIO_BUILD_SRC_FLAGS: -Wdouble-promotion -Wall -Werror
 
-      - name: Build scales
+  unit-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Platformio
         run: |
-          ~/.platformio/penv/bin/platformio run -e scales-calibration-dfu
-
+          python3 -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/master/scripts/get-platformio.py)"
       - name: Run tests
         run: |
           ~/.platformio/penv/bin/platformio test -e test
 
   static-analysis:
+    name: Static Analysis
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-
+    strategy:
+      fail-fast: false
+      matrix:
+        environment:
+          - "gaggia-lego-stlink"
+          - "scales-calibration-stlink"
+          # - "uart-stm"
+          # - "uart-esp"
     steps:
-      - name: Checkout master
-        uses: actions/checkout@v2
-
-      - name: Set up Python
-        uses: actions/setup-python@v1
-
+      - uses: actions/checkout@v3
       - name: Install Platformio
         run: |
           python3 -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/master/scripts/get-platformio.py)"
-
-      - name: Run static analysis on main project
-        if: success() || failure()
+      - name: Run static analysis on ${{ matrix.environment }}
         run: |
-          ~/.platformio/penv/bin/platformio check -e gaggia-lego-stlink --fail-on-defect medium --fail-on-defect high
-
-      - name: Run static analysis on scales
-        if: success() || failure()
-        run: |
-          ~/.platformio/penv/bin/platformio check -e scales-calibration-dfu --fail-on-defect medium --fail-on-defect high
-
-      - name: Run static analysis on uart-stm
-        if: success() || failure()
-        run: |
-          ~/.platformio/penv/bin/platformio check -e uart-stm --fail-on-defect medium --fail-on-defect high
-
-      - name: Run static analysis on uart-esp
-        if: success() || failure()
-        run: |
-          ~/.platformio/penv/bin/platformio check -e uart-esp --fail-on-defect medium --fail-on-defect high
+          ~/.platformio/penv/bin/platformio check -e ${{ matrix.environment }} --fail-on-defect medium --fail-on-defect high

--- a/platformio.ini
+++ b/platformio.ini
@@ -141,10 +141,11 @@ build_flags =
 	-DSERIAL_TX_BUFFER_SIZE=256
 	-DSERIAL_RX_BUFFER_SIZE=256
 	-DBEAUTIFY_GRAPH
-	-Wdouble-promotion -Wall
 	-O0
 build_unflags =
 	-Os
+build_src_flags =
+	-Wdouble-promotion -Wall
 check_patterns =
 	src
 

--- a/src/lcd/nextion.cpp
+++ b/src/lcd/nextion.cpp
@@ -222,7 +222,7 @@ void lcdSetTemperature(int val) {
 void lcdSetWeight(float val) {
   char tmp[5];
   int check = snprintf(tmp, sizeof(tmp), "%.1f", static_cast<double>(val));
-  if (check > 0 && check <= sizeof(tmp))
+  if (check > 0 && static_cast<unsigned int>(check) <= sizeof(tmp))
     myNex.writeStr("weight.txt", tmp);
 }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -12,11 +12,11 @@ void log(const char* prefix, const char* file, const int line, const char* msg, 
   va_list args;
   va_start(args, msg);
   int check = vsnprintf(msgBuf, LOG_MAX_STRING_LEN, msg, args);
-  if (check > 0 && check <= sizeof(msgBuf))
+  if (check > 0 && static_cast<unsigned int>(check) <= sizeof(msgBuf))
     va_end(args);
 
   char logLineBuf[LOG_MAX_PREFIX_LEN + LOG_MAX_STRING_LEN];
   check = snprintf(logLineBuf, sizeof(logLineBuf), "%s (%s:%i): %s", prefix, file, line, msgBuf);
-  if (check > 0 && check <= sizeof(logLineBuf))
+  if (check > 0 && static_cast<unsigned int>(check) <= sizeof(logLineBuf))
     USART_DEBUG.println(logLineBuf);
 }


### PR DESCRIPTION
Code change does the following...
- GitHub actions now use matrixes to run jobs in parallel
- GitHub actions Compile Sketch task will now fail on compiler warnings
- Moved compiler warning flags to build_src_flags, to stop library warnings from bleeding into output.
- Fix signed to unsigned comparison
- Disabled uart from the static analysis since the product is still a prototype (maybe unneeded?)

Action prior to fixing warnings: https://github.com/MajorArkwolf/gaggiuino/actions/runs/4273450104
Action post fixing warnings:  https://github.com/MajorArkwolf/gaggiuino/actions/runs/4273458299