### PR TITLE
Adaptive phases 

### DIFF
--- a/lib/Common/profiling_phases.h
+++ b/lib/Common/profiling_phases.h
@@ -45,8 +45,8 @@ struct Transition {
   long time;
 
   Transition(): start(-1), end(-1), curve(TransitionCurve::INSTANT), time(0) {}
+  Transition(float targetValue, TransitionCurve curve = TransitionCurve::INSTANT, long time = 0):  start(-1), end(targetValue), curve(curve), time(time) {}
   Transition(float start, float end, TransitionCurve curve = TransitionCurve::LINEAR, long time = 0): start(start), end(end), curve(curve), time(time) {}
-  Transition(float value):  start(value), end(value), curve(TransitionCurve::INSTANT), time(0) {}
 };
 
 struct Phase {
@@ -55,7 +55,7 @@ struct Phase {
   float restriction;
   PhaseStopConditions stopConditions;
 
-  float getTarget(uint32_t timeInPhase) const;
+  float getTarget(uint32_t timeInPhase, const ShotSnapshot& shotSnapshotAtStart) const;
   float getRestriction() const;
   bool isStopConditionReached(SensorState& currentState, const eepromValues_t currentConfig, uint32_t timeInShot, ShotSnapshot stateAtPhaseStart) const;
 };
@@ -89,10 +89,11 @@ class CurrentPhase {
 private:
   int index;
   const Phase* phase;
+  const ShotSnapshot* shotSnapshotAtStart;
   unsigned long timeInPhase;
 
 public:
-  CurrentPhase(int index, const Phase& phase, uint32_t timeInPhase);
+  CurrentPhase(int index, const Phase& phase, uint32_t timeInPhase, const ShotSnapshot& shotSnapshotAtStart);
   CurrentPhase(const CurrentPhase& currentPhase);
 
   Phase getPhase();
@@ -109,7 +110,7 @@ private:
   Profile& profile;
   size_t currentPhaseIdx = 0; // The index at which the profiler currently is.
   ShotSnapshot phaseChangedSnapshot = ShotSnapshot{0, 0, 0, 0, 0, 0}; // State when the profiler move to this currentPhaseIdx
-  CurrentPhase currentPhase = CurrentPhase(0, profile.phases[0], 0);
+  CurrentPhase currentPhase = CurrentPhase(0, profile.phases[0], 0, phaseChangedSnapshot);
 
 public:
   PhaseProfiler(Profile& profile);


### PR DESCRIPTION
Allowing a transition to have -1 in the start. 
When this happens the Profiler uses the actual value that was achieved at the end of the previous phase.

#### Example for a pressure Phase:
If at the end of the previous Phase the pressure was 1.3bar 
AND ramp is defined as Transition { -1, 9 , LINEAR } 
THEN profiler will treat it as a Transition { 1.3, 9, LINEAR } at runtime 

#### Example for a flow Phase:
IF we have Pressure Based PI followed by a flow profile
AND flow profile is defined as Transition { -1, 2.5, LINEAR, 3000 }
AND at the end of the PI we had an actual flow of 0.4ml/sec
THEN profiler will treat the transition as Transition { 0.4, 2.5, LINEAR, 3000 }