### PR TITLE
Stop on weight weird behaviour

### DIFF
--- a/lib/Common/profiling_phases.h
+++ b/lib/Common/profiling_phases.h
@@ -35,7 +35,7 @@ struct PhaseStopConditions {
   float weight = -1; //example: when pushed weight >0 stop this phase)
   float waterPumpedInPhase = -1;
 
-  bool isReached(SensorState& state, const eepromValues_t currentConfig, long timeInShot, ShotSnapshot stateAtPhaseStart) const;
+  bool isReached(SensorState& state, long timeInShot, ShotSnapshot stateAtPhaseStart) const;
 };
 
 struct Transition {
@@ -61,7 +61,7 @@ struct Phase {
 
   float getTarget(uint32_t timeInPhase, const ShotSnapshot& shotSnapshotAtStart) const;
   float getRestriction() const;
-  bool isStopConditionReached(SensorState& currentState, const eepromValues_t currentConfig, uint32_t timeInShot, ShotSnapshot stateAtPhaseStart) const;
+  bool isStopConditionReached(SensorState& currentState, uint32_t timeInShot, ShotSnapshot stateAtPhaseStart) const;
 };
 
 struct GlobalStopConditions {
@@ -69,7 +69,7 @@ struct GlobalStopConditions {
   float weight = -1;
   float waterPumped = -1;
 
-  bool isReached(const SensorState& state, const eepromValues_t currentConfig, long timeInShot);
+  bool isReached(const SensorState& state, uint32_t timeInShot);
 };
 
 struct Profile {
@@ -123,7 +123,7 @@ private:
 public:
   PhaseProfiler(Profile& profile);
   // Gets the profiling phase we should be in based on the timeInShot and the Sensors state
-  void updatePhase(uint32_t timeInShot, SensorState& state, const eepromValues_t currentConfig);
+  void updatePhase(uint32_t timeInShot, SensorState& state);
   CurrentPhase& getCurrentPhase();
   bool isFinished();
   void reset();


### PR DESCRIPTION
Not sure why we needed to introduce the runningCfg on the phases parameters. 

For GlobalStopConditions - this is duplicating the exact same logic from updateProfilerPhases.  The shotTarget is passed already to the GlobalStopConditions using the exact same logic during `updateProfilerPhases` (see [here](https://github.com/Zer0-bit/gaggiuino/blob/22d288e7d358b3875e167176c5691935df735c7c/src/gaggiuino.ino#L461)).

For PhaseStopConditions - this part is useless. The GlobalStopConditions are already evaluated on every cycle of the profiler. Doing it also on the PhaseStopConditions is duplicating the logic. I've tested this with predictive and with scales and I can't see any bug. 