### PR TITLE
Extra zero on considered flow

### DIFF
--- a/src/gaggiuino.ino
+++ b/src/gaggiuino.ino
@@ -372,7 +372,7 @@ static void lcdRefresh(void) {
         lcdSetFlow(
           currentState.weight > 0.4f // currentState.weight is always zero if scales are not present
             ? currentState.smoothedWeightFlow * 10.f
-            : fmaxf(currentState.consideredFlow * 100.f, currentState.smoothedPumpFlow * 10.f)
+            : fmaxf(currentState.consideredFlow * 10.f, currentState.smoothedPumpFlow * 10.f)
         );
         break;
       default:


### PR DESCRIPTION
Removes an extra zero on the consideredFlow multiplier that can occasionally show up as random flow spikes on the graph, such as this one.

![IMG_3336](https://github.com/Zer0-bit/gaggiuino/assets/41182432/0290003f-254e-44b8-b000-896f08f77e26)

Been running it for a while, and the spikes are gone. Debug process is on discord, but summarized here:


Okay, if `isOutputFlow` is true but `currentState.weight < 0.4` , then we'll update `consideredFlow` to be above 0. 
```
      if (predictiveWeight.isOutputFlow() || currentState.weight > 0.4f) {
        float flowPerClick = getPumpFlowPerClick(currentState.smoothedPressure);
        float actualFlow = (consideredFlow > pumpClicks * flowPerClick) ? consideredFlow : pumpClicks * flowPerClick;
        // Probabilistically the flow is lower if the shot is just started winding up and we're flow profiling
        // if (runningCfg.flowProfileState && currentState.isPressureRising) {
        //   if (currentState.smoothedPressure < runningCfg.flowProfilePressureTarget * 0.9f) {
        //     actualFlow *= 0.6f;
        //   }
        // }
        currentState.consideredFlow = smoothConsideredFlow.updateEstimate(actualFlow);
        currentState.shotWeight = scalesIsPresent() ? currentState.weight : currentState.shotWeight + actualFlow;
      }```

But we might end up using consideredFlow instead of `smoothedPumpFlow`
```        lcdSetFlow(
          currentState.weight > 0.4f // currentState.weight is always zero if scales are not present
            ? currentState.smoothedWeightFlow * 10.f
            : fmaxf(currentState.consideredFlow * 100.f, currentState.smoothedPumpFlow * 10.f)
        ); 
```

when we dropped the coefficients in the kalman filter here, it seems that we should have dropped considered flow's multiplier. https://github.com/Zer0-bit/gaggiuino/commit/3cc47b0faa8a32d3822238b0398f1e354cf8ca61
