### PR TITLE
Async tare + cleanup

### DIFF
--- a/lib/Common/sensors_state.h
+++ b/lib/Common/sensors_state.h
@@ -8,6 +8,7 @@ struct SensorState {
   bool hotWaterSwitchState;
   bool isSteamForgottenON;
   bool scalesPresent;
+  bool tarePending;
   float temperature;          // °C
   /* calculated water temperature as wanted but not guaranteed
   due to boiler having a hard limit of 4ml/s heat capacity */

--- a/src/gaggiuino.h
+++ b/src/gaggiuino.h
@@ -76,7 +76,6 @@ unsigned long steamTime;
 
 //scales vars
 Measurements weightMeasurements(4);
-bool tareDone         = false;
 
 // brew detection vars
 bool brewActive = false;

--- a/src/gaggiuino.ino
+++ b/src/gaggiuino.ino
@@ -150,28 +150,27 @@ static void sensorsReadTemperature(void) {
 
 static void sensorsReadWeight(void) {
   uint32_t elapsedTime = millis() - scalesTimer;
-  currentState.scalesPresent = scalesIsPresent();
-  if (currentState.scalesPresent && elapsedTime > GET_SCALES_READ_EVERY) {
-    if(!tareDone) {
-      scalesTare(); //Tare at the start of any weighing cycle
-      if (!nonBrewModeActive && (fabsf(scalesGetWeight().value) > 0.3f)) {
-        tareDone = false;
+
+  if (elapsedTime > GET_SCALES_READ_EVERY) {
+    currentState.scalesPresent = scalesIsPresent();
+    if (currentState.scalesPresent) {
+      if (currentState.tarePending) {
+        scalesTare();
+        weightMeasurements.clear();
+        weightMeasurements.add(scalesGetWeight());
+        currentState.tarePending = false;
       }
       else {
-        weightMeasurements.clear();
-        tareDone = true;
+        weightMeasurements.add(scalesGetWeight());
       }
+      currentState.weight = weightMeasurements.latest().value;
     }
 
-    weightMeasurements.add(scalesGetWeight());
-    currentState.weight = weightMeasurements.latest().value;
-
     if (brewActive) {
-      currentState.shotWeight = tareDone ? currentState.weight : 0.f;
+      currentState.shotWeight = currentState.tarePending ? 0.f : currentState.weight;
       currentState.weightFlow = fmax(0.f, weightMeasurements.measurementChange().changeSpeed());
       currentState.smoothedWeightFlow = smoothScalesFlow.updateEstimate(currentState.weightFlow);
     }
-
     scalesTimer = millis();
   }
 }
@@ -207,7 +206,7 @@ static void calculateWeightAndFlow(void) {
 
   if (brewActive) {
     // Marking for tare in case smth has gone wrong and it has exited tare already.
-    if (currentState.weight < -0.3f) tareDone = false;
+    if (currentState.weight < -.3f) currentState.tarePending = true;
 
     if (elapsedTime > REFRESH_FLOW_EVERY) {
       flowTimer = millis();
@@ -231,7 +230,7 @@ static void calculateWeightAndFlow(void) {
           }
         }
         currentState.consideredFlow = smoothConsideredFlow.updateEstimate(actualFlow);
-        currentState.shotWeight = scalesIsPresent() ? currentState.shotWeight : currentState.shotWeight + actualFlow;
+        currentState.shotWeight = currentState.scalesPresent ? currentState.shotWeight : currentState.shotWeight + actualFlow;
       }
       currentState.waterPumped += consideredFlow;
     }
@@ -449,7 +448,7 @@ void lcdLoadDefaultProfileTrigger(void) {
 
 void lcdScalesTareTrigger(void) {
   LOG_VERBOSE("Tare scales");
-  if (scalesIsPresent()) scalesTare();
+  if (currentState.scalesPresent) currentState.tarePending = true;
 }
 
 void lcdHomeScreenScalesTrigger(void) {
@@ -459,12 +458,13 @@ void lcdHomeScreenScalesTrigger(void) {
 
 void lcdBrewGraphScalesTareTrigger(void) {
   LOG_VERBOSE("Predictive scales tare action completed!");
-  if (!scalesIsPresent()) {
-    if (currentState.shotWeight > 0.f) {
-      currentState.shotWeight = 0.f;
-      predictiveWeight.setIsForceStarted(true);
-    } else predictiveWeight.setIsForceStarted(true);
-  } else scalesTare();
+  if (currentState.scalesPresent) {
+    currentState.tarePending = true;
+  }
+  else {
+    currentState.shotWeight = 0.f;
+    predictiveWeight.setIsForceStarted(true);
+  } 
 }
 
 void lcdRefreshElementsTrigger(void) {
@@ -765,7 +765,7 @@ static void brewDetect(void) {
 }
 
 static void brewParamsReset(void) {
-  tareDone                 = false;
+  currentState.tarePending = true;
   currentState.shotWeight  = 0.f;
   currentState.pumpFlow    = 0.f;
   currentState.weight      = 0.f;


### PR DESCRIPTION
TAKE THREE

Tare is consistently async now
Remote scales poll was not under GET_SCALES_READ_EVERY
scalesIsPresent is called only once and consistently stored and used from currentState
