### PR TITLE
fix: profiles options, add numeric step input for layout, align icons…

### DIFF
--- a/webserver/web-interface/.eslintrc.js
+++ b/webserver/web-interface/.eslintrc.js
@@ -51,6 +51,7 @@ module.exports = {
     'react/jsx-no-bind': 'off',
     'react/prop-types': 'off',
     'react/jsx-fragments': 'off',
+    'react/require-default-props': 'off',
     'no-plusplus': 'off',
     'import/no-extraneous-dependencies': [
       'error',

--- a/webserver/web-interface/src/components/Tabs/tabs_settings.tsx
+++ b/webserver/web-interface/src/components/Tabs/tabs_settings.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  Box, TextField, Button, Tabs, Tab, Typography, useTheme, Switch,
+  Box, TextField, Button, Tabs, Tab, Typography, useTheme, Grid, StandardTextFieldProps,
 } from '@mui/material';
 import TemperatureIcon from '@mui/icons-material/DeviceThermostat';
 import CoffeeMakerIcon from '@mui/icons-material/CoffeeMaker';
@@ -22,27 +22,36 @@ function TabPanel(props: TabPanelProps) {
   const {
     children, value, index, ...other
   } = props;
+  const theme = useTheme();
+  const styles = {
+    [theme.breakpoints.up('lg')]: {
+      width: '50%',
+    },
+    [theme.breakpoints.down('lg')]: {
+      width: '60%',
+    },
+    [theme.breakpoints.down('md')]: {
+      width: '100%',
+    },
+  };
 
   return (
-    <div
+    <Box
       role="tabpanel"
       hidden={value !== index}
       id={`vertical-tabpanel-${index}`}
       aria-labelledby={`vertical-tab-${index}`}
+      sx={styles}
       {...other}
     >
       {value === index && (
         <Box sx={{ p: 3 }}>
-          <Typography>{children}</Typography>
+          {children}
         </Box>
       )}
-    </div>
+    </Box>
   );
 }
-
-TabPanel.defaultProps = {
-  children: null,
-};
 
 function a11yProps(index: number) {
   return {
@@ -51,21 +60,85 @@ function a11yProps(index: number) {
   };
 }
 
+const textFieldStyles = { width: '5ch', '& input': { textAlign: 'center' } };
+
+const sharedTextFieldProps: StandardTextFieldProps = {
+  sx: textFieldStyles, id: 'contained-read-only-input', defaultValue: '0', InputProps: { readOnly: true, inputMode: 'numeric' },
+};
+const sharedGridProps = {
+  alignItems: 'center', justifyContent: 'space-between',
+};
+
+const iconButtonStyles = { flex: '0 0 5%', '& .MuiButton-startIcon': { marginRight: '0px' } };
+
+interface NumericStateBoxProps {
+  fieldDisplay: string;
+  value: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onAddBtnClick?: () => void;
+  onSubBtnClick?: () => void;
+}
+
+function NumericStepInput({
+  fieldDisplay, onChange, onAddBtnClick, onSubBtnClick, value,
+}: NumericStateBoxProps): JSX.Element {
+  return (
+    <Grid container spacing={2} {...sharedGridProps}>
+      <Grid item md={5} xs={3}>
+        <Typography>
+          {`${fieldDisplay}:`}
+        </Typography>
+      </Grid>
+      <Grid item xs={2}>
+        <TextField variant="standard" value={value} {...sharedTextFieldProps} onChange={onChange} />
+      </Grid>
+      <Grid container spacing={2} item xs={5}>
+        <Grid item order={{ sm: 1, xs: 2 }}>
+          <Button variant="contained" startIcon={<RemoveIcon />} sx={iconButtonStyles} onClick={onSubBtnClick} />
+        </Grid>
+        <Grid item order={{ sm: 2, xs: 1 }}>
+          <Button variant="contained" startIcon={<AddIcon />} sx={iconButtonStyles} onClick={onAddBtnClick} />
+        </Grid>
+      </Grid>
+    </Grid>
+  );
+}
+
 export default function VerticalTabs() {
   const [value, setValue] = React.useState(0);
 
-  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+  const defaultBoilerState = {
+    waterTemp: 93, steamTemp: 155, tempOffset: 0, hpwr: 0, mainDivider: 0, brewDivider: 0,
+  };
+  const [boilerState, setBoilerState] = React.useState(defaultBoilerState);
+
+  const handleTabsChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue);
   };
 
   const theme = useTheme();
+  const boxStyles = {
+    border: `1px solid ${theme.palette.divider}`, borderRadius: '16px', padding: '10px',
+  };
+
+  const onAddBtnClick = (stateKey: keyof typeof defaultBoilerState) => {
+    setBoilerState((prev) => ({ ...prev, [stateKey]: prev[stateKey] + 1 }));
+  };
+
+  const onSubBtnClick = (stateKey: keyof typeof defaultBoilerState) => {
+    setBoilerState((prev) => ({ ...prev, [stateKey]: prev[stateKey] - 1 }));
+  };
+
+  const onNumericInputChange = (stateKey: keyof typeof defaultBoilerState, eventValue: string) => {
+    setBoilerState((prev) => ({ ...prev, [stateKey]: eventValue }));
+  };
 
   return (
     <Box sx={{
-      flexGrow: 1, bgcolor: 'background.paper', display: 'flex', height: '100%', width: '100%', borderRadius: '16px',
+      flexGrow: 1, bgcolor: 'background.paper', display: 'flex', height: '100%', borderRadius: '16px',
     }}
     >
-      <Tabs orientation="vertical" variant="standard" value={value} onChange={handleChange} sx={{ borderRight: 1, borderColor: 'divider' }}>
+      <Tabs orientation="vertical" variant="standard" value={value} onChange={handleTabsChange} sx={{ borderRight: 1, borderColor: 'divider' }}>
         <Tab icon={<TemperatureIcon />} label="Boiler" {...a11yProps(0)} />
         <Tab icon={<CoffeeMakerIcon />} label="System" {...a11yProps(1)} />
         <Tab icon={<FlareIcon />} label="Led" {...a11yProps(2)} />
@@ -73,120 +146,54 @@ export default function VerticalTabs() {
         <Tab icon={<LogoDevIcon />} label="SysLog" {...a11yProps(4)} />
       </Tabs>
       <TabPanel value={value} index={0}>
-        <Box sx={{
-          justifyContent: 'space-between', alignItems: 'center', display: 'flex', border: `1px solid ${theme.palette.divider}`, position: 'relative', borderRadius: '16px', width: '100%', padding: '10px', gap: '10px',
-        }}
-        >
-          <Typography>Water Temperature:</Typography>
-          <TextField variant="standard" sx={{ width: '5ch', '& input': { textAlign: 'center' } }} id="contained-read-only-input" defaultValue="0" InputProps={{ readOnly: true }} />
-          <Button variant="contained" startIcon={<RemoveIcon />} sx={{ flex: '0 0 5%' }} />
-          <Button variant="contained" startIcon={<AddIcon />} sx={{ flex: '0 0 5%' }} />
+        <Box sx={boxStyles}>
+          <NumericStepInput fieldDisplay="Water Temperature" value={boilerState.waterTemp.toString()} onChange={(e) => onNumericInputChange('waterTemp', e.target.value)} onAddBtnClick={() => onAddBtnClick('waterTemp')} onSubBtnClick={() => onSubBtnClick('waterTemp')} />
         </Box>
-        <Box sx={{
-          justifyContent: 'space-between', alignItems: 'center', display: 'flex', border: `1px solid ${theme.palette.divider}`, position: 'relative', borderRadius: '16px', width: '100%', padding: '10px', gap: '10px',
-        }}
-        >
-          <Typography>Steam Temperature:</Typography>
-          <TextField variant="standard" sx={{ width: '5ch', '& input': { textAlign: 'center' } }} id="contained-read-only-input" defaultValue="0" InputProps={{ readOnly: true }} />
-          <Button variant="contained" startIcon={<RemoveIcon />} sx={{ flex: '0 0 5%' }} />
-          <Button variant="contained" startIcon={<AddIcon />} sx={{ flex: '0 0 5%' }} />
+        <Box sx={boxStyles}>
+          <NumericStepInput fieldDisplay="Steam Temperature" value={boilerState.steamTemp.toString()} onChange={(e) => onNumericInputChange('steamTemp', e.target.value)} onAddBtnClick={() => onAddBtnClick('steamTemp')} onSubBtnClick={() => onSubBtnClick('steamTemp')} />
         </Box>
-        <Box sx={{
-          justifyContent: 'space-between', alignItems: 'center', display: 'flex', border: `1px solid ${theme.palette.divider}`, position: 'relative', borderRadius: '16px', width: '100%', padding: '10px', gap: '10px',
-        }}
-        >
-          <Typography>Temperature Offset:</Typography>
-          <TextField variant="standard" sx={{ width: '5ch', '& input': { textAlign: 'center' } }} id="contained-read-only-input" defaultValue="0" InputProps={{ readOnly: true }} />
-          <Button variant="contained" startIcon={<RemoveIcon />} sx={{ flex: '0 0 5%' }} />
-          <Button variant="contained" startIcon={<AddIcon />} sx={{ flex: '0 0 5%' }} />
+        <Box sx={boxStyles}>
+          <NumericStepInput fieldDisplay="Temperature Offset" value={boilerState.tempOffset.toString()} onChange={(e) => onNumericInputChange('tempOffset', e.target.value)} onAddBtnClick={() => onAddBtnClick('tempOffset')} onSubBtnClick={() => onSubBtnClick('tempOffset')} />
         </Box>
-        <Box sx={{
-          justifyContent: 'space-between', alignItems: 'center', display: 'flex', border: `1px solid ${theme.palette.divider}`, position: 'relative', borderRadius: '16px', width: '100%', padding: '10px', gap: '10px',
-        }}
-        >
-          <Typography>HPWR:</Typography>
-          <TextField variant="standard" sx={{ width: '5ch', '& input': { textAlign: 'center' } }} id="contained-read-only-input" defaultValue="0" InputProps={{ readOnly: true }} />
-          <Button variant="contained" startIcon={<RemoveIcon />} sx={{ flex: '0 0 5%' }} />
-          <Button variant="contained" startIcon={<AddIcon />} sx={{ flex: '0 0 5%' }} />
+        <Box sx={boxStyles}>
+          <NumericStepInput fieldDisplay="HPWR" value={boilerState.hpwr.toString()} onChange={(e) => onNumericInputChange('hpwr', e.target.value)} onAddBtnClick={() => onAddBtnClick('hpwr')} onSubBtnClick={() => onSubBtnClick('hpwr')} />
         </Box>
-        <Box sx={{
-          justifyContent: 'space-between', alignItems: 'center', display: 'flex', border: `1px solid ${theme.palette.divider}`, position: 'relative', borderRadius: '16px', width: '100%', padding: '10px', gap: '10px',
-        }}
-        >
-          <Typography>Main Divider:</Typography>
-          <TextField variant="standard" sx={{ width: '5ch', '& input': { textAlign: 'center' } }} id="contained-read-only-input" defaultValue="0" InputProps={{ readOnly: true }} />
-          <Button variant="contained" startIcon={<RemoveIcon />} sx={{ flex: '0 0 5%' }} />
-          <Button variant="contained" startIcon={<AddIcon />} sx={{ flex: '0 0 5%' }} />
+        <Box sx={boxStyles}>
+          <NumericStepInput fieldDisplay="Main Divider" value={boilerState.mainDivider.toString()} onChange={(e) => onNumericInputChange('mainDivider', e.target.value)} onAddBtnClick={() => onAddBtnClick('mainDivider')} onSubBtnClick={() => onSubBtnClick('mainDivider')} />
         </Box>
-        <Box sx={{
-          justifyContent: 'space-between', alignItems: 'center', display: 'flex', border: `1px solid ${theme.palette.divider}`, position: 'relative', borderRadius: '16px', width: '100%', padding: '10px', gap: '10px',
-        }}
-        >
-          <Typography>Brew Divider:</Typography>
-          <TextField variant="standard" sx={{ width: '5ch', '& input': { textAlign: 'center' } }} id="contained-read-only-input" defaultValue="0" InputProps={{ readOnly: true }} />
-          <Button variant="contained" startIcon={<RemoveIcon />} sx={{ flex: '0 0 5%' }} />
-          <Button variant="contained" startIcon={<AddIcon />} sx={{ flex: '0 0 5%' }} />
+        <Box sx={boxStyles}>
+          <NumericStepInput fieldDisplay="Brew Divider" value={boilerState.brewDivider.toString()} onChange={(e) => onNumericInputChange('brewDivider', e.target.value)} onAddBtnClick={() => onAddBtnClick('brewDivider')} onSubBtnClick={() => onSubBtnClick('brewDivider')} />
         </Box>
       </TabPanel>
       <TabPanel value={value} index={1}>
-        <Box sx={{
-          justifyContent: 'space-between', alignItems: 'center', display: 'flex', border: `1px solid ${theme.palette.divider}`, position: 'relative', borderRadius: '16px', width: '100%', padding: '10px', gap: '10px',
-        }}
-        >
-          <Typography>Scales Factor 1:</Typography>
-          <TextField variant="standard" sx={{ width: '5ch', '& input': { textAlign: 'center' } }} id="contained-read-only-input" defaultValue="0" InputProps={{ readOnly: true }} />
-          <Button variant="contained" startIcon={<RemoveIcon />} sx={{ flex: '0 0 5%' }} />
-          <Button variant="contained" startIcon={<AddIcon />} sx={{ flex: '0 0 5%' }} />
+        <Box sx={boxStyles}>
+          <NumericStepInput fieldDisplay="Scales Factor 1" value="0" />
         </Box>
-        <Box sx={{
-          justifyContent: 'space-between', alignItems: 'center', display: 'flex', border: `1px solid ${theme.palette.divider}`, position: 'relative', borderRadius: '16px', width: '100%', padding: '10px', gap: '10px',
-        }}
-        >
-          <Typography>Scales Factor 2:</Typography>
-          <TextField variant="standard" sx={{ width: '5ch', '& input': { textAlign: 'center' } }} id="contained-read-only-input" defaultValue="0" InputProps={{ readOnly: true }} />
-          <Button variant="contained" startIcon={<RemoveIcon />} sx={{ flex: '0 0 5%' }} />
-          <Button variant="contained" startIcon={<AddIcon />} sx={{ flex: '0 0 5%' }} />
+        <Box sx={boxStyles}>
+          <NumericStepInput fieldDisplay="Scales Factor 2" value="0" />
         </Box>
-        <Box sx={{
-          justifyContent: 'space-between', alignItems: 'center', display: 'flex', border: `1px solid ${theme.palette.divider}`, position: 'relative', borderRadius: '16px', width: '100%', padding: '10px', gap: '10px',
-        }}
-        >
-          <Typography>LCD Sleep:</Typography>
-          <TextField variant="standard" sx={{ width: '5ch', '& input': { textAlign: 'center' } }} id="contained-read-only-input" defaultValue="0" InputProps={{ readOnly: true }} />
-          <Button variant="contained" startIcon={<RemoveIcon />} sx={{ flex: '0 0 5%' }} />
-          <Button variant="contained" startIcon={<AddIcon />} sx={{ flex: '0 0 5%' }} />
+        <Box sx={boxStyles}>
+          <NumericStepInput fieldDisplay="LCD Sleep" value="0" />
         </Box>
-        <Box sx={{
-          justifyContent: 'space-between', alignItems: 'center', display: 'flex', border: `1px solid ${theme.palette.divider}`, position: 'relative', borderRadius: '16px', width: '100%', padding: '10px', gap: '10px',
-        }}
-        >
-          <Typography>System Update rate:</Typography>
-          <TextField variant="standard" sx={{ width: '5ch', '& input': { textAlign: 'center' } }} id="contained-read-only-input" defaultValue="0" InputProps={{ readOnly: true }} />
-          <Button variant="contained" startIcon={<RemoveIcon />} sx={{ flex: '0 0 5%' }} />
-          <Button variant="contained" startIcon={<AddIcon />} sx={{ flex: '0 0 5%' }} />
+        <Box sx={boxStyles}>
+          <NumericStepInput fieldDisplay="System Update Rate" value="0" />
         </Box>
-        <Box sx={{
-          justifyContent: 'space-between', alignItems: 'center', display: 'flex', border: `1px solid ${theme.palette.divider}`, position: 'relative', borderRadius: '16px', width: '100%', padding: '10px', gap: '10px',
-        }}
-        >
-          <Typography>Pump Zero:</Typography>
-          <TextField variant="standard" sx={{ width: '5ch', '& input': { textAlign: 'center' } }} id="contained-read-only-input" defaultValue="0" InputProps={{ readOnly: true }} />
-          <Button variant="contained" startIcon={<RemoveIcon />} sx={{ flex: '0 0 5%' }} />
-          <Button variant="contained" startIcon={<AddIcon />} sx={{ flex: '0 0 5%' }} />
+        <Box sx={boxStyles}>
+          <NumericStepInput fieldDisplay="Pump Zero" value="23.0" />
         </Box>
-        <Box sx={{
-          justifyContent: 'space-between', alignItems: 'center', display: 'flex', border: `1px solid ${theme.palette.divider}`, position: 'relative', borderRadius: '16px', width: '100%', padding: '10px', gap: '10px',
-        }}
-        >
-          <Typography>Reset to defaults:</Typography>
-          <Switch defaultChecked />
-        </Box>
+
         <Box sx={{
           justifyContent: 'center', alignItems: 'center', display: 'flex', border: `1px solid ${theme.palette.divider}`, position: 'relative', borderRadius: '16px', width: '100%', padding: '10px', gap: '10px',
         }}
         >
           <Typography>Dark/Light toggle:</Typography>
           <ThemeModeToggle />
+        </Box>
+        <Box sx={{
+          justifyContent: 'center', alignItems: 'center', display: 'flex', border: `1px solid ${theme.palette.divider}`, position: 'relative', borderRadius: '16px', width: '100%', padding: '10px', gap: '10px',
+        }}
+        >
+          <Button>Reset to defaults</Button>
         </Box>
       </TabPanel>
       <TabPanel value={value} index={2}>

--- a/webserver/web-interface/src/pages/home/Profiles.tsx
+++ b/webserver/web-interface/src/pages/home/Profiles.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import {
-  Card, Container, useTheme, Typography, CardContent, CardActions, Paper, TextareaAutosize, Alert,
+  Card, Container, useTheme, Typography, CardContent, CardActions, Paper, TextareaAutosize, Alert, MenuItem,
 } from '@mui/material';
 import IconButton from '@mui/material/IconButton';
 import QrCodeIcon from '@mui/icons-material/QrCode';
@@ -153,10 +153,10 @@ export default function Profiles() {
                                 value={element.value}
                                 onChange={(event) => handleSelectChange(event, element.id)}
                               >
-                                <option value="1">Preinfusion</option>
-                                <option value="2">Soak</option>
-                                <option value="3">Flow</option>
-                                <option value="4">Pressure</option>
+                                <MenuItem value="1">Preinfusion</MenuItem>
+                                <MenuItem value="2">Soak</MenuItem>
+                                <MenuItem value="3">Flow</MenuItem>
+                                <MenuItem value="4">Pressure</MenuItem>
                               </Select>
                             </Grid>
                           );


### PR DESCRIPTION

* remove default props eslint rule - don't need with TS
* add breakpoints to make settings boxes more responsive
* move common styles to constants
* numeric step input
  * use grid to align items and props to allow change functions to be sent
* super basic placeholder state   
* fix profile menu items

<img width="785" alt="image" src="https://github.com/Zer0-bit/gaggiuino/assets/25180830/fd18856a-ca3c-479f-88d0-99bdcef0c6e4">
<img width="683" alt="image" src="https://github.com/Zer0-bit/gaggiuino/assets/25180830/0504816a-5675-438f-97b3-321bf70eaa6e">
<img width="240" alt="image" src="https://github.com/Zer0-bit/gaggiuino/assets/25180830/cbc6146f-6728-44b9-8410-8f59322571d8">
