### PR TITLE
Make compile-sketch great again

### DIFF
--- a/.github/workflows/compile-sketch.yml
+++ b/.github/workflows/compile-sketch.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
   
 env:
-  BUILD_CACHE: build-cache # Directory where build-wrapper output will be placed
+  BUILD_CACHE: build-cache
 
 jobs:
   coding-style:

--- a/.github/workflows/compile-sketch.yml
+++ b/.github/workflows/compile-sketch.yml
@@ -7,25 +7,24 @@ on:
     branches: [dev, release/stm32-blackpill, fix/*]
   # Manual trigger
   workflow_dispatch:
+  
+env:
+  BUILD_CACHE: build-cache # Directory where build-wrapper output will be placed
 
 jobs:
   coding-style:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     steps:
       - name: Checkout master
         uses: actions/checkout@v3
-
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: "16"
-
       - name: Install eclint
         run: |
           npm install -g eclint
-
       - name: Check coding style
         run: |
           eclint check $(sh .eclint-files.sh)
@@ -34,37 +33,65 @@ jobs:
     name: Compilation
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    env:
-      BUILD_WRAPPER_OUT_DIR: build_wrapper_output_directory # Directory where build-wrapper output will be placed
     strategy:
       fail-fast: false
       matrix:
         environment:
-          - name: Main
+          - name: Main (Lego)
             command: "lego-stlink"
+          - name: Main (PCB)
+            command: "all-pcb-stlink"
           - name: Scales
-            command: "scales-calibration-dfu"
+            command: "scales-calibration-stlink"
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - uses: actions/setup-python@v4
-      - name: Install Platformio
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+      - name: Cache build
+        uses: actions/cache@v3
+        with:
+          path: .pio/build/${{ matrix.environment.command }}
+          key: ${{ env.BUILD_CACHE }}-${{ matrix.environment.command }}
+      - name: Run compilation for ${{ matrix.environment.name }}
         run: |
-          python3 -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/master/scripts/get-platformio.py)"
-      - name: Install sonar-scanner
-        uses: SonarSource/sonarcloud-github-c-cpp@v1
-      - name: Run build-wrapper on ${{ matrix.environment.name }}
-        run: |
-          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} ~/.platformio/penv/bin/platformio run -e ${{ matrix.environment.command }}
+          pio run -e ${{ matrix.environment.command }}
         env:
           PLATFORMIO_BUILD_SRC_FLAGS: -Wdouble-promotion -Wall -Werror
+
+  sonar-scanner:
+    name: Sonar-Scanner
+    runs-on: ubuntu-latest
+    needs: [compile]
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        environment:
+          - name: Main (Lego)
+            command: "lego-stlink"
+          - name: Main (PCB)
+            command: "all-pcb-stlink"
+          - name: Scales
+            command: "scales-calibration-stlink"
+    steps:
+      - name: Install sonar-scanner
+        uses: SonarSource/sonarcloud-github-c-cpp@v1
+      - uses: actions/cache@v3
+        with:
+          path: |
+            .pio/build/${{ matrix.environment.command }}
+          key: ${{ env.BUILD_CACHE }}-${{ matrix.environment.command }}
       - name: Run sonar-scanner
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          sonar-scanner --define sonar.cfamily.build-wrapper-output="${{ env.BUILD_WRAPPER_OUT_DIR }}"
+          sonar-scanner --define sonar.cfamily.build-wrapper-output=".pio/build/${{ matrix.environment.command }}"
 
   unit-tests:
     name: Unit Tests
@@ -72,15 +99,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
-      - name: Install Platformio
-        run: |
-          python3 -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/master/scripts/get-platformio.py)"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
       - name: Run tests
         run: |
-          ~/.platformio/penv/bin/platformio test -e test || true
-      - name: Run tests
-        run: |
-          ~/.platformio/penv/bin/platformio test -e test
+          pio test -e test
 
   static-analysis:
     name: Static Analysis
@@ -90,17 +116,18 @@ jobs:
       matrix:
         environment:
           - "lego-stlink"
+          - "all-pcb-stlink"
           - "scales-calibration-stlink"
-          # - "uart-stm"
-          # - "uart-esp"
     steps:
       - uses: actions/checkout@v3
-      - name: Install Platformio
-        run: |
-          python3 -c "$(curl -fsSL https://raw.githubusercontent.com/platformio/platformio/master/scripts/get-platformio.py)"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
       - name: Run static analysis on ${{ matrix.environment }}
         run: |
-          ~/.platformio/penv/bin/platformio check -e ${{ matrix.environment }} --fail-on-defect medium --fail-on-defect high
+          pio check -e ${{ matrix.environment }} --fail-on-defect medium --fail-on-defect high
 
   web-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Went to build release/stm32-blackpill on my PC and noticed a bunch of compilation errors. 
- Went to GitHub actions to check the latest build and noticed it doesn't build "all-pcb-stlink"
- Added "all-pcb-stlink" as a build target
- Noticed that compile-sketch.yml was broken af
- Fixed compile-sketch.yml

Added sonar-scannar as a dependent job and removed the need for the weird intermediate step of having a build output folder. This also means that anyone who forks this repo can at least run the compilation actions as sonar requires secrets that wont be present in forks.