### PR TITLE
fix: react version

### DIFF
--- a/webserver/web-interface/package.json
+++ b/webserver/web-interface/package.json
@@ -15,7 +15,7 @@
     "camelcase": "^6.3.0",
     "chart.js": "^4.3.0",
     "fs-extra": "^10.1.0",
-    "react": "^15.0.0 || ^17.0.0 || ^18.0.0",
+    "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.8.0",


### PR DESCRIPTION
tiny little thing, but the react version shouldn't be anything but one version. Since 18.2 is what it was originally and since 18.2 is what is in the lockfile, use 18.2. This doesn't change anything since the lockfile already specifies 18.2, but still