### PR TITLE
Feature/momentary buttons

### DIFF
--- a/src/gaggiuino.ino
+++ b/src/gaggiuino.ino
@@ -701,6 +701,9 @@ static void profiling(void) {
       setPumpOff();
       closeValve();
       brewActive = false;
+      #ifdef BREW_MOMENTARY
+      resetMomentaryBrew();
+      #endif
     } else if (currentPhase.getType() == PHASE_TYPE::PHASE_TYPE_PRESSURE) {
       float newBarValue = currentPhase.getTarget();
       float flowRestriction =  currentPhase.getRestriction();

--- a/src/peripherals/peripherals.h
+++ b/src/peripherals/peripherals.h
@@ -9,19 +9,19 @@
 #include <Arduino.h>
 
 // Variables for momentary buttons
-#ifdef steamMomentary
+#ifdef STEAM_MOMENTARY
 static int steamCurrentState = HIGH;
 static int steamLastState = HIGH;
 static bool steamPressed = false;
 static unsigned long steamLastDebounceTime;
 #endif
-#ifdef brewMomentary
+#ifdef BREW_MOMENTARY
 static int brewCurrentState = HIGH;
 static int brewLastState = HIGH;
 static bool brewPressed = false;
 static unsigned long brewLastDebounceTime;
 #endif
-#ifdef waterMomentary
+#if defined(waterPin) && defined(WATER_MOMENTARY)
 static int waterCurrentState = HIGH;
 static int waterLastState = HIGH;
 static bool waterPressed = false;
@@ -103,10 +103,17 @@ static inline bool momentaryButtonPressed(int pin, int *currentState, int *lastS
   return *buttonIsDown;
 }
 
+#ifdef BREW_MOMENTARY
+static inline void resetMomentaryBrew()
+{
+  brewPressed = false;
+}
+#endif
+
 //Function to get the state of the brew switch button
 //returns true or false based on the read P(power) value
 static inline bool brewState(void) {
-  #ifdef brewMomentary
+  #ifdef BREW_MOMENTARY
   return momentaryButtonPressed(brewPin, &brewCurrentState, &brewLastState, &brewPressed, &brewLastDebounceTime);
   #else
   return digitalRead(brewPin) == LOW; // pin will be low when switch is ON.
@@ -116,7 +123,7 @@ static inline bool brewState(void) {
 // Returns HIGH when switch is OFF and LOW when ON
 // pin will be high when switch is ON.
 static inline bool steamState(void) {
-  #ifdef steamMomentary
+  #ifdef STEAM_MOMENTARY
   return momentaryButtonPressed(steamPin, &steamCurrentState, &steamLastState, &steamPressed, &steamLastDebounceTime);
   #else
   return digitalRead(steamPin) == LOW; // pin will be low when switch is ON.
@@ -125,7 +132,7 @@ static inline bool steamState(void) {
 
 static inline bool waterPinState(void) {
   #ifdef waterPin
-  #ifdef waterMomentary
+  #ifdef WATER_MOMENTARY
   return momentaryButtonPressed(waterPin, &waterCurrentState, &waterLastState, &waterPressed, &waterLastDebounceTime);
   #else
   return digitalRead(waterPin) == LOW; // pin will be low when switch is ON.

--- a/src/peripherals/peripherals.h
+++ b/src/peripherals/peripherals.h
@@ -2,9 +2,31 @@
 #ifndef PERIPHERALS_H
 #define PERIPHERALS_H
 
+#define DEBOUNCE_DELAY_MS 50
+
 #include "pindef.h"
 #include "peripherals.h"
 #include <Arduino.h>
+
+// Variables for momentary buttons
+#ifdef steamMomentary
+static int steamCurrentState = HIGH;
+static int steamLastState = HIGH;
+static bool steamPressed = false;
+static unsigned long steamLastDebounceTime;
+#endif
+#ifdef brewMomentary
+static int brewCurrentState = HIGH;
+static int brewLastState = HIGH;
+static bool brewPressed = false;
+static unsigned long brewLastDebounceTime;
+#endif
+#ifdef waterMomentary
+static int waterCurrentState = HIGH;
+static int waterLastState = HIGH;
+static bool waterPressed = false;
+static unsigned long waterLastDebounceTime;
+#endif
 
 static inline void pinInit(void) {
   #if defined(LEGO_VALVE_RELAY)
@@ -59,21 +81,55 @@ static inline void setSteamBoilerRelayOff(void) {
   #endif
 }
 
+static inline bool momentaryButtonPressed(int pin, int *currentState, int *lastState, bool *buttonIsDown, unsigned long *lastDebounceTime)
+{
+  int buttonRead = digitalRead(pin);
+
+  if (buttonRead != *lastState) {
+      *lastDebounceTime = millis();
+  }
+
+  if ((millis() - *lastDebounceTime) > DEBOUNCE_DELAY_MS) {
+    if (buttonRead != *currentState)
+    {
+      *currentState = buttonRead;
+      if (*currentState == LOW)
+      {
+        *buttonIsDown = !*buttonIsDown;
+      }
+    }
+  }
+  *lastState = buttonRead;
+  return *buttonIsDown;
+}
+
 //Function to get the state of the brew switch button
 //returns true or false based on the read P(power) value
 static inline bool brewState(void) {
+  #ifdef brewMomentary
+  return momentaryButtonPressed(brewPin, &brewCurrentState, &brewLastState, &brewPressed, &brewLastDebounceTime);
+  #else
   return digitalRead(brewPin) == LOW; // pin will be low when switch is ON.
+  #endif
 }
 
 // Returns HIGH when switch is OFF and LOW when ON
 // pin will be high when switch is ON.
 static inline bool steamState(void) {
+  #ifdef steamMomentary
+  return momentaryButtonPressed(steamPin, &steamCurrentState, &steamLastState, &steamPressed, &steamLastDebounceTime);
+  #else
   return digitalRead(steamPin) == LOW; // pin will be low when switch is ON.
+  #endif
 }
 
 static inline bool waterPinState(void) {
   #ifdef waterPin
+  #ifdef waterMomentary
+  return momentaryButtonPressed(waterPin, &waterCurrentState, &waterLastState, &waterPressed, &waterLastDebounceTime);
+  #else
   return digitalRead(waterPin) == LOW; // pin will be low when switch is ON.
+  #endif
   #else
   return false;
   #endif


### PR DESCRIPTION
Added momentary buttons options for Brew and Steam.

This would be useful if: You want a cheaper all in one low powered front panel and/or you have a different machine already with momentary switches you'd like to re-use.

It basically read and set's it's own internal variables for it's button state in Perhiperals.h, and then resets the internal brew state when brewing has finished.

to enable it you can add the compiler flags:
```
-DSTEAM_MOMENTARY
-DBREW_MOMENTARY
-DWATER_MOMENTARY
```

if the flags are not set, the compiled code should be the same as the original firmware.