### PR TITLE
Add [UT] (utility) profiles and rename Boiler Off to add to that category

### DIFF
--- a/profiles/Boiler Off.md
+++ b/profiles/Boiler Off.md
@@ -1,1 +1,0 @@
-Helper profile - turns the temperature off, can be useful in automations or just to keep the machine on while not actively heating.

--- a/profiles/[UT] Boiler Off.json
+++ b/profiles/[UT] Boiler Off.json
@@ -1,0 +1,38 @@
+{
+  "name": "[UT] Boiler Off",
+  "phases": [
+    {
+      "name": "",
+      "type": "FLOW",
+      "target": {
+        "start": 0,
+        "end": 0,
+        "curve": "INSTANT",
+        "time": 0
+      },
+      "restriction": 0,
+      "stopConditions": {
+        "time": 0,
+        "pressureAbove": 0,
+        "pressureBelow": 0,
+        "flowAbove": 0,
+        "flowBelow": 0,
+        "weight": 0,
+        "waterPumpedInPhase": 0
+      },
+      "skip": false,
+      "waterTemperature": 0
+    }
+  ],
+  "globalStopConditions": {
+    "time": 0,
+    "weight": 0,
+    "waterPumped": 0
+  },
+  "waterTemperature": 1,
+  "recipe": {
+    "coffeeIn": 0,
+    "coffeeOut": 0,
+    "ratio": 0
+  }
+}

--- a/profiles/[UT] Boiler Off.md
+++ b/profiles/[UT] Boiler Off.md
@@ -1,0 +1,1 @@
+Utility profile - turns the boiler heaters off, can be useful in automations or just to keep the machine on while not actively heating.

--- a/profiles/[UT] Cycle 100.json
+++ b/profiles/[UT] Cycle 100.json
@@ -1,0 +1,38 @@
+{
+  "name": "[UT] Cycle 100",
+  "phases": [
+    {
+      "name": "",
+      "type": "FLOW",
+      "target": {
+        "start": 0,
+        "end": 4,
+        "curve": "INSTANT",
+        "time": 0
+      },
+      "restriction": 0,
+      "stopConditions": {
+        "time": 0,
+        "pressureAbove": 0,
+        "pressureBelow": 0,
+        "flowAbove": 0,
+        "flowBelow": 0,
+        "weight": 0,
+        "waterPumpedInPhase": 0
+      },
+      "skip": false,
+      "waterTemperature": 0
+    }
+  ],
+  "globalStopConditions": {
+    "time": 0,
+    "weight": 0,
+    "waterPumped": 100
+  },
+  "waterTemperature": 92,
+  "recipe": {
+    "coffeeIn": 0,
+    "coffeeOut": 0,
+    "ratio": 0
+  }
+}

--- a/profiles/[UT] Cycle 100.md
+++ b/profiles/[UT] Cycle 100.md
@@ -1,0 +1,1 @@
+Utility profile - Cycles 100 ml of water at 4 ml/s. The intent is to replace the water in the Gaggia aluminum boiler without losing heat.

--- a/profiles/[UT] Cycle 130.json
+++ b/profiles/[UT] Cycle 130.json
@@ -1,0 +1,38 @@
+{
+  "name": "[UT] Cycle 130",
+  "phases": [
+    {
+      "name": "",
+      "type": "FLOW",
+      "target": {
+        "start": 0,
+        "end": 4,
+        "curve": "INSTANT",
+        "time": 0
+      },
+      "restriction": 0,
+      "stopConditions": {
+        "time": 0,
+        "pressureAbove": 0,
+        "pressureBelow": 0,
+        "flowAbove": 0,
+        "flowBelow": 0,
+        "weight": 0,
+        "waterPumpedInPhase": 0
+      },
+      "skip": false,
+      "waterTemperature": 0
+    }
+  ],
+  "globalStopConditions": {
+    "time": 0,
+    "weight": 0,
+    "waterPumped": 130
+  },
+  "waterTemperature": 92,
+  "recipe": {
+    "coffeeIn": 0,
+    "coffeeOut": 0,
+    "ratio": 0
+  }
+}

--- a/profiles/[UT] Cycle 130.md
+++ b/profiles/[UT] Cycle 130.md
@@ -1,0 +1,1 @@
+Utility profile - Cycles 130 ml of water at 4 ml/s. The intent is to replace the water in the Gaggia brass boiler without losing heat.

--- a/profiles/[UT] PZ Cal 1.3.json
+++ b/profiles/[UT] PZ Cal 1.3.json
@@ -1,0 +1,126 @@
+{
+  "name": "[UT] PZ Cal 1.3",
+  "phases": [
+    {
+      "name": "",
+      "type": "FLOW",
+      "target": {
+        "start": 4,
+        "end": 4,
+        "curve": "INSTANT",
+        "time": 0
+      },
+      "restriction": 0,
+      "stopConditions": {
+        "time": 3000,
+        "pressureAbove": 0,
+        "pressureBelow": 0,
+        "flowAbove": 0,
+        "flowBelow": 0,
+        "weight": 0,
+        "waterPumpedInPhase": 0
+      },
+      "skip": false,
+      "waterTemperature": 0
+    },
+    {
+      "name": "",
+      "type": "FLOW",
+      "target": {
+        "start": 0,
+        "end": 0,
+        "curve": "INSTANT",
+        "time": 0
+      },
+      "restriction": 0,
+      "stopConditions": {
+        "time": 17000,
+        "pressureAbove": 0,
+        "pressureBelow": 0,
+        "flowAbove": 0,
+        "flowBelow": 0,
+        "weight": 0,
+        "waterPumpedInPhase": 0
+      },
+      "skip": false,
+      "waterTemperature": 0
+    },
+    {
+      "name": "",
+      "type": "FLOW",
+      "target": {
+        "start": 1,
+        "end": 1,
+        "curve": "INSTANT",
+        "time": 0
+      },
+      "restriction": 0,
+      "stopConditions": {
+        "time": 15000,
+        "pressureAbove": 0,
+        "pressureBelow": 0,
+        "flowAbove": 0,
+        "flowBelow": 0,
+        "weight": 0,
+        "waterPumpedInPhase": 0
+      },
+      "skip": false,
+      "waterTemperature": 0
+    },
+    {
+      "name": "",
+      "type": "FLOW",
+      "target": {
+        "start": 2,
+        "end": 2,
+        "curve": "INSTANT",
+        "time": 0
+      },
+      "restriction": 0,
+      "stopConditions": {
+        "time": 20000,
+        "pressureAbove": 0,
+        "pressureBelow": 0,
+        "flowAbove": 0,
+        "flowBelow": 0,
+        "weight": 0,
+        "waterPumpedInPhase": 0
+      },
+      "skip": false,
+      "waterTemperature": 0
+    },
+    {
+      "name": "",
+      "type": "FLOW",
+      "target": {
+        "start": 3,
+        "end": 3,
+        "curve": "INSTANT",
+        "time": 0
+      },
+      "restriction": 0,
+      "stopConditions": {
+        "time": 15000,
+        "pressureAbove": 0,
+        "pressureBelow": 0,
+        "flowAbove": 0,
+        "flowBelow": 0,
+        "weight": 0,
+        "waterPumpedInPhase": 0
+      },
+      "skip": false,
+      "waterTemperature": 0
+    }
+  ],
+  "globalStopConditions": {
+    "time": 0,
+    "weight": 0,
+    "waterPumped": 0
+  },
+  "waterTemperature": 1,
+  "recipe": {
+    "coffeeIn": 0,
+    "coffeeOut": 0,
+    "ratio": 0
+  }
+}

--- a/profiles/[UT] PZ Cal 1.3.md
+++ b/profiles/[UT] PZ Cal 1.3.md
@@ -1,8 +1,8 @@
-Utility profile - Profile to calibrate PZ
+Utility profile - PZ Calibration
 
-**Preparation:**
-- Turn off Brew/Temperature Delta (Save)
-- Turn off BT Scales, HW Scales, turn on Forced Predictive (Save)
+**Setup:**
+- Turn off Brew/Temperature Delta; save
+- Turn off BT Scales, HW Scales, turn on Forced Predictive; save
 - Optional: set PZ Cal to the startup profile so boiler doesn't heat on boot
 - Reboot (otherwise Brew Delta stays on)
 - Wait for temp <25 C
@@ -16,8 +16,8 @@ Utility profile - Profile to calibrate PZ
 - Weigh cup + water after the shot. Target is 100 g; adjust PZ up if weight is over and down if weight is under 
 - Repeat test steps as needed
 
-**Finishing:**
-- Reset Brew/Temperature Delta (Save)
-- Turn on desired Scales option, turn off others (Save)
-- Reset startup profile
+**Reset:**
+- Reset Brew/Temperature Delta; save
+- Turn on desired Scales option, turn off others; save
+- Reset startup profile if changed
 - Reboot

--- a/profiles/[UT] PZ Cal 1.3.md
+++ b/profiles/[UT] PZ Cal 1.3.md
@@ -1,0 +1,23 @@
+Utility profile - Profile to calibrate PZ
+
+**Preparation:**
+- Turn off Brew/Temperature Delta (Save)
+- Turn off BT Scales, HW Scales, turn on Forced Predictive (Save)
+- Optional: set PZ Cal to the startup profile so boiler doesn't heat on boot
+- Reboot (otherwise Brew Delta stays on)
+- Wait for temp <25 C
+- Run the first 5 seconds of the profile to clear pressure
+- Run the first 5 seconds of the profile and verify pressure stays ≤0.1 bar. If necessary, backflush, clean, and remove shower screen for the test. 
+
+**Test:**
+- Tare a cup on a scale
+- Start PZ Cal *without placing the cup*
+- After initial 3 seconds of flow, wipe shower screen, drip tray, and then place the cup. The flow test will start at 20 sec.
+- Weigh cup + water after the shot. Target is 100 g; adjust PZ up if weight is over and down if weight is under 
+- Repeat test steps as needed
+
+**Finishing:**
+- Reset Brew/Temperature Delta (Save)
+- Turn on desired Scales option, turn off others (Save)
+- Reset startup profile
+- Reboot

--- a/profiles/[UT] Test OPV.json
+++ b/profiles/[UT] Test OPV.json
@@ -1,18 +1,18 @@
 {
-  "name": "Boiler Off",
+  "name": "[UT] Test OPV",
   "phases": [
     {
       "name": "",
-      "type": "FLOW",
+      "type": "PRESSURE",
       "target": {
-        "start": 0,
-        "end": 0,
-        "curve": "LINEAR",
+        "start": 15,
+        "end": 15,
+        "curve": "INSTANT",
         "time": 0
       },
       "restriction": 0,
       "stopConditions": {
-        "time": 0,
+        "time": 20000,
         "pressureAbove": 0,
         "pressureBelow": 0,
         "flowAbove": 0,
@@ -29,7 +29,7 @@
     "weight": 0,
     "waterPumped": 0
   },
-  "waterTemperature": 9,
+  "waterTemperature": 1,
   "recipe": {
     "coffeeIn": 0,
     "coffeeOut": 0,

--- a/profiles/[UT] Test OPV.md
+++ b/profiles/[UT] Test OPV.md
@@ -1,0 +1,1 @@
+Utility profile - Tests OPV and system pressure by running unlimited flow with a pressure target of 15 bar. Before running, insert a portafilter with a blank basket. 

--- a/profiles/[UT] Tube Fill.json
+++ b/profiles/[UT] Tube Fill.json
@@ -1,0 +1,148 @@
+{
+  "name": "[UT] Tube Fill",
+  "phases": [
+    {
+      "name": "",
+      "type": "FLOW",
+      "target": {
+        "start": 2,
+        "end": 2,
+        "curve": "INSTANT",
+        "time": 0
+      },
+      "restriction": 0,
+      "stopConditions": {
+        "time": 15000,
+        "pressureAbove": 0,
+        "pressureBelow": 0,
+        "flowAbove": 0,
+        "flowBelow": 0,
+        "weight": 0,
+        "waterPumpedInPhase": 0
+      },
+      "skip": false,
+      "waterTemperature": 0
+    },
+    {
+      "name": "",
+      "type": "FLOW",
+      "target": {
+        "start": 1,
+        "end": 1,
+        "curve": "INSTANT",
+        "time": 0
+      },
+      "restriction": 0,
+      "stopConditions": {
+        "time": 15000,
+        "pressureAbove": 0,
+        "pressureBelow": 0,
+        "flowAbove": 0,
+        "flowBelow": 0,
+        "weight": 0,
+        "waterPumpedInPhase": 0
+      },
+      "skip": false,
+      "waterTemperature": 0
+    },
+    {
+      "name": "",
+      "type": "FLOW",
+      "target": {
+        "start": 2,
+        "end": 2,
+        "curve": "INSTANT",
+        "time": 0
+      },
+      "restriction": 0,
+      "stopConditions": {
+        "time": 15000,
+        "pressureAbove": 0,
+        "pressureBelow": 0,
+        "flowAbove": 0,
+        "flowBelow": 0,
+        "weight": 0,
+        "waterPumpedInPhase": 0
+      },
+      "skip": false,
+      "waterTemperature": 0
+    },
+    {
+      "name": "",
+      "type": "FLOW",
+      "target": {
+        "start": 1,
+        "end": 1,
+        "curve": "INSTANT",
+        "time": 0
+      },
+      "restriction": 0,
+      "stopConditions": {
+        "time": 15000,
+        "pressureAbove": 0,
+        "pressureBelow": 0,
+        "flowAbove": 0,
+        "flowBelow": 0,
+        "weight": 0,
+        "waterPumpedInPhase": 0
+      },
+      "skip": false,
+      "waterTemperature": 0
+    },
+    {
+      "name": "",
+      "type": "FLOW",
+      "target": {
+        "start": 2,
+        "end": 2,
+        "curve": "INSTANT",
+        "time": 0
+      },
+      "restriction": 0,
+      "stopConditions": {
+        "time": 15000,
+        "pressureAbove": 0,
+        "pressureBelow": 0,
+        "flowAbove": 0,
+        "flowBelow": 0,
+        "weight": 0,
+        "waterPumpedInPhase": 0
+      },
+      "skip": false,
+      "waterTemperature": 0
+    },
+    {
+      "name": "",
+      "type": "FLOW",
+      "target": {
+        "start": 1,
+        "end": 1,
+        "curve": "INSTANT",
+        "time": 0
+      },
+      "restriction": 0,
+      "stopConditions": {
+        "time": 15000,
+        "pressureAbove": 0,
+        "pressureBelow": 0,
+        "flowAbove": 0,
+        "flowBelow": 0,
+        "weight": 0,
+        "waterPumpedInPhase": 0
+      },
+      "skip": false,
+      "waterTemperature": 0
+    }
+  ],
+  "globalStopConditions": {
+    "time": 0,
+    "weight": 0,
+    "waterPumped": 0
+  },
+  "waterTemperature": 1,
+  "recipe": {
+    "coffeeIn": 0,
+    "coffeeOut": 0,
+    "ratio": 0
+  }
+}

--- a/profiles/[UT] Tube Fill.md
+++ b/profiles/[UT] Tube Fill.md
@@ -1,0 +1,1 @@
+Utility profile - For use with the T-fitting pressure transducer installation. 1:30 of alternating 2 ml/s and 1 ml/s flow.


### PR DESCRIPTION
Utility profiles:
- Boiler Off; turns off heaters
- Cycle 100; cycles 100 ml water through (for Aluminum boiler) 
- Cycle 130; cycles 130 ml water through (for Brass boiler)
- PZ Cal 1.3; profile and instructions to calibrate PZ
- Test OPV; tests OPV and system up to 15 bar
- Tube Fill; fills pressure transducer tubing (T-fitting install)